### PR TITLE
Expression id in span tree

### DIFF
--- a/build/run.js
+++ b/build/run.js
@@ -127,7 +127,7 @@ commands.build.rust = async function(argv) {
 
         console.log('Checking the resulting WASM size.')
         let stats = fss.statSync(paths.dist.wasm.mainOptGz)
-        let limit = 3.32
+        let limit = 3.33
         let size = Math.round(100 * stats.size / 1024 / 1024) / 100
         if (size > limit) {
             throw(`Output file size exceeds the limit (${size}MB > ${limit}MB).`)

--- a/src/rust/ide/ast/impl/src/lib.rs
+++ b/src/rust/ide/ast/impl/src/lib.rs
@@ -75,11 +75,14 @@ impl IdMap {
         IdMap {vec}
     }
     /// Assigns Span to given ID.
-    pub fn insert(&mut self, span:Span, id:Id) {
-        self.vec.push((span,id));
+    pub fn insert(&mut self, span:impl Into<Span>, id:Id) {
+        self.vec.push((span.into(),id));
+    }
+    /// Generate random Uuid for span.
+    pub fn generate(&mut self, span:impl Into<Span>) {
+        self.vec.push((span.into(),Uuid::new_v4()));
     }
 }
-
 
 
 

--- a/src/rust/ide/ast/impl/src/prefix.rs
+++ b/src/rust/ide/ast/impl/src/prefix.rs
@@ -3,6 +3,7 @@
 use crate::prelude::*;
 
 use crate::Ast;
+use crate::Id;
 use crate::crumbs::Located;
 use crate::crumbs::PrefixCrumb;
 use crate::known;
@@ -11,13 +12,22 @@ use crate::Shifted;
 
 use utils::vec::VecExt;
 
+/// Struct representing an element of a Prefix Chain: an argument applied over the function.
 #[derive(Clone,Debug)]
+pub struct Argument {
+    /// An argument ast with offset between it and previous arg or function.
+    pub sast      : Shifted<Ast>,
+    /// The id of Prefix AST of this argument application.
+    pub prefix_id : Option<Id>,
+}
+
 /// Result of flattening a sequence of prefix applications.
+#[derive(Clone,Debug)]
 pub struct Chain {
     /// The function (initial application target)
     pub func : Ast,
     /// Subsequent arguments applied over the function.
-    pub args : Vec<Shifted<Ast>>,
+    pub args : Vec<Argument>,
 }
 
 impl Chain {
@@ -25,12 +35,14 @@ impl Chain {
     /// App(App(a,b),c) into flat list where first element is the function and
     /// then arguments are placed: `{func:a, args:[b,c]}`.
     pub fn new(ast:&known::Prefix) -> Chain {
-        fn run(ast:&known::Prefix, mut acc: &mut Vec<Shifted<Ast>>) -> Ast {
+        fn run(ast:&known::Prefix, mut acc: &mut Vec<Argument>) -> Ast {
             let func = match known::Prefix::try_from(&ast.func) {
                 Ok(lhs_app) => run(&lhs_app, &mut acc),
                 _           => ast.func.clone(),
             };
-            acc.push(Shifted{wrapped:ast.arg.clone(),off:ast.off});
+            let sast      = Shifted{wrapped:ast.arg.clone(),off:ast.off};
+            let prefix_id = ast.id();
+            acc.push(Argument{sast,prefix_id});
             func
         }
 
@@ -54,7 +66,9 @@ impl Chain {
             // Case like `+ a b`
             let func = section.opr.clone();
             let right_chain = Chain::new_non_strict(&section.arg);
-            let mut args = vec![Shifted{wrapped:right_chain.func, off:section.off}];
+            let sast      = Shifted{wrapped:right_chain.func, off:section.off};
+            let prefix_id = section.id();
+            let mut args = vec![Argument{sast,prefix_id}];
             args.extend(right_chain.args);
             Chain {func,args}
         } else {
@@ -87,7 +101,7 @@ impl Chain {
         let mut i = 0;
         self.args.iter().map(move |arg| {
             i += 1;
-            Located::new(&func_crumbs[i..],&arg.wrapped)
+            Located::new(&func_crumbs[i..],&arg.sast.wrapped)
         })
     }
 
@@ -96,11 +110,11 @@ impl Chain {
     pub fn fold_arg(&mut self) {
         if let Some(arg) = self.args.pop_front() {
             let new_prefix = Prefix{
-                arg  : arg.wrapped,
+                arg  : arg.sast.wrapped,
                 func : self.func.clone_ref(),
-                off  : arg.off,
+                off  : arg.sast.off,
             };
-            self.func = new_prefix.into();
+            self.func = Ast::new(new_prefix,arg.prefix_id);
         }
     }
 
@@ -120,6 +134,7 @@ mod tests {
     use super::*;
 
     use utils::test::ExpectTuple;
+    use uuid::Uuid;
 
     #[test]
     fn prefix_chain() {
@@ -127,13 +142,15 @@ mod tests {
         let b = Ast::var("b");
         let c = Ast::var("c");
 
-        let a_b = Ast::prefix(a.clone(),b.clone());
-        let a_b_c = Ast::prefix(a_b.clone(),c.clone());
+        let a_b = Ast::prefix(a.clone(),b.clone()).with_id(Uuid::new_v4());
+        let a_b_c = Ast::prefix(a_b.clone(),c.clone()).with_id(Uuid::new_v4());
 
         let chain = Chain::try_new(&a_b_c).unwrap();
         assert_eq!(chain.func, a);
-        assert_eq!(chain.args[0].wrapped, b);
-        assert_eq!(chain.args[1].wrapped, c);
+        assert_eq!(chain.args[0].sast.wrapped, b);
+        assert_eq!(chain.args[1].sast.wrapped, c);
+        assert_eq!(chain.args[0].prefix_id, a_b.id);
+        assert_eq!(chain.args[1].prefix_id, a_b_c.id);
 
         let (arg1,arg2) = chain.enumerate_args().expect_tuple();
         assert_eq!(arg1.item, &b);

--- a/src/rust/ide/parser/src/lib.rs
+++ b/src/rust/ide/parser/src/lib.rs
@@ -99,7 +99,11 @@ impl Parser {
     /// Program is expected to be single non-empty line module. The line's AST is
     /// returned. Panics otherwise.
     pub fn parse_line(&self, program:impl Str) -> FallibleResult<Ast> {
-        let module = self.parse_module(program,default())?;
+        self.parse_line_with_id_map(program,default())
+    }
+
+    pub fn parse_line_with_id_map(&self, program:impl Str, id_map:IdMap) -> FallibleResult<Ast> {
+        let module = self.parse_module(program,id_map)?;
 
         let mut lines = module.lines.clone().into_iter().filter_map(|line| {
             line.elem

--- a/src/rust/ide/parser/src/lib.rs
+++ b/src/rust/ide/parser/src/lib.rs
@@ -97,11 +97,12 @@ impl Parser {
     }
 
     /// Program is expected to be single non-empty line module. The line's AST is
-    /// returned. Panics otherwise.
+    /// returned. Panics otherwise. The program is parsed with empty IdMap.
     pub fn parse_line(&self, program:impl Str) -> FallibleResult<Ast> {
         self.parse_line_with_id_map(program,default())
     }
-
+    /// Program is expected to be single non-empty line module. The line's AST is returned. Panics
+    /// otherwise.
     pub fn parse_line_with_id_map(&self, program:impl Str, id_map:IdMap) -> FallibleResult<Ast> {
         let module = self.parse_module(program,id_map)?;
 

--- a/src/rust/ide/parser/tests/ast.rs
+++ b/src/rust/ide/parser/tests/ast.rs
@@ -73,7 +73,7 @@ pub fn flatten_prefix_test() {
         assert_eq!(flattened.args.len() + 1, pieces.len()); // +1 because `func` piece is separate field
         assert_eq!(&flattened.func.repr(),piece_itr.next().unwrap());
         flattened.args.iter().zip(piece_itr).for_each(|(lhs,rhs)|{
-            assert_eq!(&lhs.sast.repr(),rhs);
+            assert_eq!(&lhs.repr(),rhs);
         })
     }
 

--- a/src/rust/ide/parser/tests/ast.rs
+++ b/src/rust/ide/parser/tests/ast.rs
@@ -73,7 +73,7 @@ pub fn flatten_prefix_test() {
         assert_eq!(flattened.args.len() + 1, pieces.len()); // +1 because `func` piece is separate field
         assert_eq!(&flattened.func.repr(),piece_itr.next().unwrap());
         flattened.args.iter().zip(piece_itr).for_each(|(lhs,rhs)|{
-            assert_eq!(&lhs.repr(),rhs);
+            assert_eq!(&lhs.sast.repr(),rhs);
         })
     }
 

--- a/src/rust/ide/span-tree/src/action.rs
+++ b/src/rust/ide/span-tree/src/action.rs
@@ -130,7 +130,10 @@ impl<'a> Implementation for node::Ref<'a> {
                     infix.into_ast()
                 } else {
                     let mut prefix = ast::prefix::Chain::new_non_strict(ast);
-                    let item       = Shifted{wrapped:new, off:DEFAULT_OFFSET};
+                    let item       = ast::prefix::Argument{
+                        sast      : Shifted{wrapped:new, off:DEFAULT_OFFSET},
+                        prefix_id : None,
+                    };
                     match ins_type {
                         BeforeTarget => prefix.args.insert(0,item),
                         AfterTarget  => prefix.args.insert(1,item),

--- a/src/rust/ide/span-tree/src/builder.rs
+++ b/src/rust/ide/span-tree/src/builder.rs
@@ -22,8 +22,8 @@ pub trait Builder : Sized {
     fn add_child
     (self, offset:usize, len:usize, kind:node::Kind, crumbs:impl IntoCrumbs) -> ChildBuilder<Self> {
         let node = Node {kind,
-            size: Size::new(len),
-            children  : vec![],
+            size          : Size::new(len),
+            children      : vec![],
             expression_id : None,
         };
         let child = node::Child { node,

--- a/src/rust/ide/span-tree/src/builder.rs
+++ b/src/rust/ide/span-tree/src/builder.rs
@@ -23,7 +23,8 @@ pub trait Builder : Sized {
     (self, offset:usize, len:usize, kind:node::Kind, crumbs:impl IntoCrumbs) -> ChildBuilder<Self> {
         let node = Node {kind,
             size: Size::new(len),
-            children  : vec![]
+            children  : vec![],
+            expression_id : None,
         };
         let child = node::Child { node,
             offset              : Size::new(offset),
@@ -50,6 +51,12 @@ pub trait Builder : Sized {
         self.node_being_built().children.push(child);
         self
     }
+
+    /// Set expression id for this node.
+    fn set_expression_id(mut self, id:ast::Id) -> Self {
+        self.node_being_built().expression_id = Some(id);
+        self
+    }
 }
 
 
@@ -71,9 +78,10 @@ impl TreeBuilder {
     pub fn new(len:usize) -> Self {
         TreeBuilder {
             built : Node {
-                kind     : node::Kind::Root,
-                size     : Size::new(len),
-                children : vec![],
+                kind          : node::Kind::Root,
+                size          : Size::new(len),
+                children      : vec![],
+                expression_id : None,
             }
         }
     }

--- a/src/rust/ide/span-tree/src/lib.rs
+++ b/src/rust/ide/span-tree/src/lib.rs
@@ -86,10 +86,11 @@ impl SpanTree {
 
 impl Default for SpanTree {
     fn default() -> Self {
-        let kind     = node::Kind::Root;
-        let size     = default();
-        let children = default();
-        let root     = Node {kind,size,children};
+        let expression_id = None;
+        let kind          = node::Kind::Root;
+        let size          = default();
+        let children      = default();
+        let root          = Node {kind,size,children,expression_id};
         Self {root}
     }
 }

--- a/src/rust/ide/span-tree/src/node.rs
+++ b/src/rust/ide/span-tree/src/node.rs
@@ -59,7 +59,8 @@ pub enum InsertType {BeforeTarget,AfterTarget,Append}
 // === Errors ===
 
 #[allow(missing_docs)]
-#[fail(display = "The crumb `{}` is invalid, only {} children present. Traversed crumbs: {:?}.", crumb,count,context)]
+#[fail(display = "The crumb `{}` is invalid, only {} children present. Traversed crumbs: {:?}.",
+    crumb,count,context)]
 #[derive(Debug,Fail,Clone)]
 pub struct InvalidCrumb {
     /// Crumb that was attempted.
@@ -90,18 +91,20 @@ pub fn parent_crumbs(crumbs:&[Crumb]) -> Option<&[Crumb]> {
 #[derive(Clone,Debug,Eq,PartialEq)]
 #[allow(missing_docs)]
 pub struct Node {
-    pub kind     : Kind,
-    pub size     : Size,
-    pub children : Vec<Child>,
+    pub kind          : Kind,
+    pub size          : Size,
+    pub children      : Vec<Child>,
+    pub expression_id : Option<ast::Id>,
 }
 
 impl Node {
     /// Create Empty node.
     pub fn new_empty(insert_type:InsertType) -> Self {
         Node {
-            kind     : Kind::Empty(insert_type),
-            size     : Size::new(0),
-            children : Vec::new(),
+            kind          : Kind::Empty(insert_type),
+            size          : Size::new(0),
+            children      : Vec::new(),
+            expression_id : None,
         }
     }
 


### PR DESCRIPTION
### Pull Request Description
This is a part of #545: The optional Expression Id was added to SpanTree, to allow reading type information by views.

### Important Notes
Due to nature of opr::Chain and prefix::Chain, I decided to not put ast reference to SpanTree node yet. But the current design needs discussion, because it is sometimes troublesome.

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/main/docs/style-guide/rust.md).
- [x] All code has been tested where possible.
- [x] All code has been profiled where possible.

