### PR TITLE
Disabled shaky test, fixed a few recently introduced unused import warnings

### DIFF
--- a/src/rust/ensogl/lib/text/src/typeface/font.rs
+++ b/src/rust/ensogl/lib/text/src/typeface/font.rs
@@ -333,7 +333,6 @@ impl scene::Extension for Registry {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use msdf::Texture;
 
     use ensogl_core_embedded_fonts::EmbeddedFonts;
     use wasm_bindgen_test::wasm_bindgen_test;

--- a/src/rust/ensogl/lib/text/src/typeface/pen.rs
+++ b/src/rust/ensogl/lib/text/src/typeface/pen.rs
@@ -84,7 +84,6 @@ impl Pen {
 mod tests {
     use super::*;
 
-    use crate::typeface::font;
     use crate::typeface::font::GlyphRenderInfo;
 
     use wasm_bindgen_test::wasm_bindgen_test;

--- a/src/rust/ensogl/src/display/shape/text/glyph/font.rs
+++ b/src/rust/ensogl/src/display/shape/text/glyph/font.rs
@@ -327,7 +327,6 @@ impl SharedRegistry {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::display::shape::text::glyph::msdf::Texture;
 
     use ensogl_core_embedded_fonts::EmbeddedFonts;
     use wasm_bindgen_test::wasm_bindgen_test;

--- a/src/rust/ide/src/model/synchronized/execution_context.rs
+++ b/src/rust/ide/src/model/synchronized/execution_context.rs
@@ -465,6 +465,9 @@ pub mod tests {
         });
     }
 
+    // TODO [mwu]
+    //   The test below has been disabled as shaky, see https://github.com/enso-org/ide/issues/637
+    #[ignore]
     #[test]
     fn detaching_all_visualizations() {
         let mock_data = MockData::new();


### PR DESCRIPTION
### Pull Request Description
The `detaching_all_visualizations` test is shaky and fails 50%. It shall be skipped until it is properly fixed.
The fix is tracked by #637.
Along the way a few random warnings that appeared recently were fixed.

### Important Notes
<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/main/docs/style-guide/rust.md).
- [x] All code has been tested where possible.
- [x] All code has been profiled where possible.

