### PR TITLE
Searcher uses node editor's controller to add nodes

### DIFF
--- a/src/rust/ide/src/view/layout.rs
+++ b/src/rust/ide/src/view/layout.rs
@@ -109,8 +109,7 @@ impl ViewLayout {
         let node_editor   = NodeEditor::new(&logger,application,graph_controller.clone_ref(),
             project_controller,visualization_controller);
         let node_editor   = node_editor.await?;
-        let node_searcher = NodeSearcher::new(world,&logger,node_editor.clone_ref(),
-            graph_controller,fonts);
+        let node_searcher = NodeSearcher::new(world,&logger,node_editor.clone_ref(),fonts);
         world.add_child(&text_editor.display_object());
         world.add_child(&node_editor);
         world.add_child(&node_searcher);

--- a/src/rust/ide/src/view/layout.rs
+++ b/src/rust/ide/src/view/layout.rs
@@ -106,8 +106,8 @@ impl ViewLayout {
         let logger        = Logger::sub(logger,"ViewLayout");
         let world         = &application.display;
         let text_editor   = TextEditor::new(&logger,world,text_controller,kb_actions,fonts);
-        let node_editor   = NodeEditor::new(&logger,application,graph_controller.clone_ref(),
-            project_controller,visualization_controller);
+        let node_editor   = NodeEditor::new
+            (&logger,application,graph_controller,project_controller,visualization_controller);
         let node_editor   = node_editor.await?;
         let node_searcher = NodeSearcher::new(world,&logger,node_editor.clone_ref(),fonts);
         world.add_child(&text_editor.display_object());

--- a/src/rust/ide/src/view/layout.rs
+++ b/src/rust/ide/src/view/layout.rs
@@ -106,11 +106,11 @@ impl ViewLayout {
         let logger        = Logger::sub(logger,"ViewLayout");
         let world         = &application.display;
         let text_editor   = TextEditor::new(&logger,world,text_controller,kb_actions,fonts);
-        let graph         = graph_controller.graph().clone_ref();
-        let node_editor   = NodeEditor::new
-            (&logger,application,graph_controller,project_controller,visualization_controller);
+        let node_editor   = NodeEditor::new(&logger,application,graph_controller.clone_ref(),
+            project_controller,visualization_controller);
         let node_editor   = node_editor.await?;
-        let node_searcher = NodeSearcher::new(world,&logger,node_editor.clone_ref(),graph,fonts);
+        let node_searcher = NodeSearcher::new(world,&logger,node_editor.clone_ref(),
+            graph_controller,fonts);
         world.add_child(&text_editor.display_object());
         world.add_child(&node_editor);
         world.add_child(&node_searcher);

--- a/src/rust/ide/src/view/node_editor.rs
+++ b/src/rust/ide/src/view/node_editor.rs
@@ -129,8 +129,8 @@ impl GraphEditorIntegratedWithController {
     }
 
     /// Get the controller associated with this graph editor.
-    pub fn controller(&self) -> controller::ExecutedGraph {
-        self.model.controller.clone_ref()
+    pub fn controller(&self) -> &controller::ExecutedGraph {
+        &self.model.controller
     }
 }
 

--- a/src/rust/ide/src/view/node_editor.rs
+++ b/src/rust/ide/src/view/node_editor.rs
@@ -127,6 +127,11 @@ impl GraphEditorIntegratedWithController {
     pub fn graph_editor(&self) -> GraphEditor {
         self.model.editor.clone_ref()
     }
+
+    /// Get the controller associated with this graph editor.
+    pub fn controller(&self) -> controller::ExecutedGraph {
+        self.model.controller.clone_ref()
+    }
 }
 
 #[derive(Debug)]

--- a/src/rust/ide/src/view/node_searcher.rs
+++ b/src/rust/ide/src/view/node_searcher.rs
@@ -23,7 +23,6 @@ pub struct NodeSearcher {
     display_object : display::object::Instance,
     node_editor    : NodeEditor,
     text_field     : TextField,
-    controller     : controller::ExecutedGraph,
     logger         : Logger,
 }
 
@@ -32,7 +31,6 @@ impl NodeSearcher {
     ( world       : &World
     , logger      : impl AnyLogger
     , node_editor : NodeEditor
-    , controller  : controller::ExecutedGraph
     , fonts       : &mut font::Registry)
     -> Self {
         let scene          = world.scene();
@@ -48,7 +46,7 @@ impl NodeSearcher {
         };
         let text_field = TextField::new(world,properties);
         display_object.add_child(&text_field.display_object());
-        let searcher = NodeSearcher{node_editor,display_object,text_field,controller,logger};
+        let searcher = NodeSearcher{node_editor,display_object,text_field,logger};
         searcher.initialize()
     }
 
@@ -67,7 +65,7 @@ impl NodeSearcher {
                 let location_hint = LocationHint::End;
                 let expression    = expression.to_string();
                 let new_node      = NewNodeInfo { expression,metadata,id,location_hint };
-                node_searcher.controller.graph().add_node(new_node);
+                node_searcher.node_editor.graph.controller().graph().add_node(new_node);
                 node_searcher.hide();
             } else {
                 // Keep only one line.

--- a/src/rust/ide/src/view/node_searcher.rs
+++ b/src/rust/ide/src/view/node_searcher.rs
@@ -23,7 +23,7 @@ pub struct NodeSearcher {
     display_object : display::object::Instance,
     node_editor    : NodeEditor,
     text_field     : TextField,
-    controller     : controller::graph::Handle,
+    controller     : controller::ExecutedGraph,
     logger         : Logger,
 }
 
@@ -32,7 +32,7 @@ impl NodeSearcher {
     ( world       : &World
     , logger      : impl AnyLogger
     , node_editor : NodeEditor
-    , controller  : controller::graph::Handle
+    , controller  : controller::ExecutedGraph
     , fonts       : &mut font::Registry)
     -> Self {
         let scene          = world.scene();
@@ -67,7 +67,7 @@ impl NodeSearcher {
                 let location_hint = LocationHint::End;
                 let expression    = expression.to_string();
                 let new_node      = NewNodeInfo { expression,metadata,id,location_hint };
-                node_searcher.controller.add_node(new_node);
+                node_searcher.controller.graph().add_node(new_node);
                 node_searcher.hide();
             } else {
                 // Keep only one line.


### PR DESCRIPTION
### Pull Request Description
Rather than passing node editor and graph controller separately to the node searcher, the searcher will be able to access node editor's controller directly.
Thanks to that, when node editor changes the displayed graph (e.g. due to entering a node), the searcher's copy of controller won't end up dangling.
This addresses #634

### Important Notes
<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/main/docs/style-guide/rust.md).
- [x] All code has been tested where possible.
- [ ] All code has been profiled where possible.

