### PR TITLE
The `flatc` usage shall be guarded by environment variable

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -72,10 +72,16 @@ need the following setup:
   Engine Services binary protocol description. Otherwise, relying on the generated files that are
   being stored in this repository is fine.
 
-  `flatc` must be in version *newer than 1.12* due to [this bug](). As of writing this text there
+  `flatc` must be in version *newer than 1.12* due to 
+  [this bug](https://github.com/google/flatbuffers/issues/5055). As of writing this text there
   are no official releases with this issue fixed, however current binaries can be obtained from the
-  project's CI [build
-  artifacts](https://github.com/google/flatbuffers/actions?query=branch%3Amaster).
+  project's CI 
+  [build artifacts](https://github.com/google/flatbuffers/actions?query=branch%3Amaster). `flatc`
+  builds from 8 May 2020 onwards have been confirmed to work.
+
+  After placing `flatc` in `PATH` you need to define the `ENSO_IDE_ENABLE_FLATC` environment
+  variable to explicitly enable regeneration of the interface files. The `flatc` is run as part of
+  `build.rs` script of the `enso-protocol package.
 
 <br/>
 


### PR DESCRIPTION
### Pull Request Description
This PR addresses #624 where engine developers get compilation errors when they try to build IDE without altering their setup.
This makes `flatc` run strictly opt-in, so the IDE will build correctly out-of-the-box.

### Important Notes
Future improvements to the situation shall be tracked in https://github.com/enso-org/ide/issues/644


### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/main/docs/style-guide/rust.md).
- [x] All code has been tested where possible.
- [x] All code has been profiled where possible.

