### PR TITLE
Obtaining child AST text span

### DIFF
--- a/src/rust/ide/lib/ast/impl/src/crumbs.rs
+++ b/src/rust/ide/lib/ast/impl/src/crumbs.rs
@@ -11,6 +11,9 @@ use crate::HasTokens;
 use crate::Shape;
 use crate::TokenConsumer;
 
+use data::text::Index;
+use data::text::Size;
+use data::text::Span;
 use utils::fail::FallibleResult;
 
 
@@ -1203,6 +1206,24 @@ pub trait TraversableAst:Sized {
 
     /// Recursively traverses AST to retrieve AST node located by given crumbs sequence.
     fn get_traversing(&self, crumbs:&[Crumb]) -> FallibleResult<&Ast>;
+
+    /// Get the `Ast` node corresponging to `Self`.
+    fn my_ast(&self) -> FallibleResult<&Ast> {
+        self.get_traversing(&[])
+    }
+
+    /// Calculate the span of the descendent AST node described by given crumbs..
+    fn span_of_descendent_at(&self, crumbs:&[Crumb]) -> FallibleResult<Span> {
+        let mut position = Index::new(0);
+        let mut ast      = self.my_ast()?;
+        for crumb in crumbs {
+            let child    = ast.get(crumb)?;
+            let child_ix = ast.index_of_child(child)?;
+            position    += Span::from_beginning_to(child_ix).size;
+            ast          = child;
+        }
+        Ok(Span::new(position,Size::new(ast.len())))
+    }
 }
 
 impl TraversableAst for Ast {
@@ -1946,7 +1967,24 @@ mod tests {
         assert_eq!(shape.get(&c1).unwrap(),&ast[0]);
         assert_eq!(shape.get(&c2).unwrap(),&ast[1]);
         assert_eq!(shape.get(&c3).unwrap(),&ast[2]);
+    }
 
 
+    // === TraversableAst ===
+
+    #[test]
+    fn traversable_ast() {
+        let ast = Ast::prefix(Ast::prefix(Ast::var("add"),Ast::number(2)),Ast::number(4));
+        let expected_code = "add 2 4";
+        assert_eq!(ast.repr(), expected_code);
+        assert_eq!(ast.my_ast().unwrap(), &ast);
+
+        let crumbs_to_two = [PrefixCrumb::Func,PrefixCrumb::Arg].into_crumbs();
+        let two           = ast.get_traversing(&crumbs_to_two).unwrap();
+        assert_eq!(two.repr(),"2");
+
+        let two_span = ast.span_of_descendent_at(&crumbs_to_two).unwrap();
+        assert_eq!(two_span, Span::from(4..5));
+        assert_eq!(&expected_code[two_span], "2");
     }
 }

--- a/src/rust/ide/lib/ast/impl/src/crumbs.rs
+++ b/src/rust/ide/lib/ast/impl/src/crumbs.rs
@@ -1218,7 +1218,7 @@ pub trait TraversableAst:Sized {
         let mut ast      = self.my_ast()?;
         for crumb in crumbs {
             let child    = ast.get(crumb)?;
-            let child_ix = ast.index_of_child(child)?;
+            let child_ix = ast.child_offset(child)?;
             position    += Span::from_beginning_to(child_ix).size;
             ast          = child;
         }

--- a/src/rust/ide/lib/ast/impl/src/lib.rs
+++ b/src/rust/ide/lib/ast/impl/src/lib.rs
@@ -35,6 +35,7 @@ pub mod prelude {
     pub use crate::Ast;
     pub use crate::traits::*;
     pub use utils::option::*;
+    pub use utils::fail::FallibleResult;
 }
 
 use crate::prelude::*;
@@ -44,6 +45,7 @@ pub use crumbs::Crumbs;
 
 use ast_macros::*;
 use data::text::Index;
+use data::text::Size;
 use data::text::Span;
 
 use serde::de::Deserializer;
@@ -94,6 +96,11 @@ impl IdMap {
 /// enum type to its variant subtype if different constructor was used.
 #[derive(Display, Debug, Fail)]
 pub struct WrongEnum {pub expected_con:String}
+
+#[allow(missing_docs)]
+#[derive(Clone,Fail,Debug)]
+#[fail(display="No such child found under given AST node.")]
+pub struct NoSuchChild;
 
 
 
@@ -302,6 +309,32 @@ impl Ast {
         //   We could do much better with HasTokens and iterative matching.
         //   Still, no need at this point.
         self.iter_recursive().find(|ast| ast.repr() == repr)
+    }
+
+    /// Get the index (relative to self) for given child node.
+    pub fn index_of_child(&self, child:&Ast) -> FallibleResult<Index> {
+        let searched_token  = Token::Ast(&child);
+        let mut found_child = false;
+        let mut position    = 0;
+        self.shape().feed_to(&mut |token:Token| {
+            if searched_token == token {
+                found_child = true
+            } else if !found_child {
+                position += token.len()
+            }
+        });
+        if found_child {
+            Ok(Index::new(position))
+        } else {
+            Err(NoSuchChild.into())
+        }
+    }
+
+    /// Get the span (relative to self) for a child node identified by given crumb.
+    pub fn span_of_child_at(&self, crumb:&Crumb) -> FallibleResult<Span> {
+        let child = self.get(crumb)?;
+        let index = self.index_of_child(child)?;
+        Ok(Span::new(index, Size::new(child.len())))
     }
 }
 
@@ -752,7 +785,7 @@ pub enum MacroPatternMatchRaw<T> {
 // === Tokenizer ===
 
 /// An enum of valid Ast tokens.
-#[derive(Debug)]
+#[derive(Clone,Debug,PartialEq)]
 pub enum Token<'a> { Off(usize), Chr(char), Str(&'a str), Ast(&'a Ast) }
 
 /// Things that can be turned into stream of tokens.
@@ -767,6 +800,11 @@ pub trait TokenConsumer {
     fn feed(&mut self, val:Token);
 }
 
+impl<F:FnMut(Token)> TokenConsumer for F {
+    fn feed(&mut self, val: Token) {
+        self(val)
+    }
+}
 
 impl HasTokens for &str {
     fn feed_to(&self, consumer:&mut impl TokenConsumer) {
@@ -852,8 +890,8 @@ impl TokenConsumer for IdMapBuilder {
     fn feed(&mut self, token:Token) {
         match token {
             Token::Off(val) => self.offset += val,
-            Token::Chr( _ ) => self.offset += 1,
-            Token::Str(val) => self.offset += val.len(),
+            Token::Chr(val) => self.offset += val.len_utf8(),
+            Token::Str(val) => self.offset += val.chars().count(),
             Token::Ast(val) => {
                 let begin = self.offset;
                 val.shape().feed_to(self);
@@ -896,8 +934,8 @@ impl TokenConsumer for LengthBuilder {
     fn feed(&mut self, token:Token) {
         match token {
             Token::Off(val) => self.length += val,
-            Token::Chr( _ ) => self.length += 1,
-            Token::Str(val) => self.length += val.len(),
+            Token::Chr(val) => self.length += val.len_utf8(),
+            Token::Str(val) => self.length += val.chars().count(),
             Token::Ast(val) => val.shape().feed_to(self),
         }
     }
@@ -908,6 +946,19 @@ impl<T:HasTokens> HasLength for T {
         let mut consumer = LengthBuilder::default();
         self.feed_to(&mut consumer);
         consumer.length
+    }
+}
+
+impl HasLength for Token<'_> {
+    fn len(&self) -> usize {
+        match self {
+            Token::Off(val) => *val,
+            Token::Chr(val) => val.len_utf8(),
+            Token::Str(val) => val.chars().count(),
+            // The below is different and cannot be unified with `LengthBuilder` because below will
+            // use the cached length, while `LengthBuilder` will traverse subtree.
+            Token::Ast(val) => val.len(),
+        }
     }
 }
 
@@ -1004,8 +1055,8 @@ where F:FnMut(Index,&Ast) {
     fn feed(&mut self, token:Token) {
         match token {
             Token::Off(val) => self.index += val,
-            Token::Chr( _ ) => self.index += 1,
-            Token::Str(val) => self.index += val.len(),
+            Token::Chr(val) => self.index += val.len_utf8(),
+            Token::Str(val) => self.index += val.chars().count(),
             Token::Ast(val) => {
                 (self.callback)(Index::new(self.index), val);
                 val.shape().feed_to(self);
@@ -1546,5 +1597,15 @@ mod tests {
         assert_eq!(tail1.off,1);
         assert_eq!(tail2.elem.as_ref().unwrap().repr(),"tail2");
         assert_eq!(tail2.off,3);
+    }
+
+    #[test]
+    fn utf8_lengths() {
+        let var = Ast::var("価");
+        assert_eq!(var.len(),1);
+
+        let idmap = var.id_map();
+        assert_eq!(idmap.vec[0].0,Span::from(0..1));
+        assert_eq!(idmap.vec[0].1,var.id.unwrap());
     }
 }

--- a/src/rust/ide/lib/ast/impl/src/lib.rs
+++ b/src/rust/ide/lib/ast/impl/src/lib.rs
@@ -312,6 +312,9 @@ impl Ast {
     }
 
     /// Get the offset relative to self for a given child node.
+    ///
+    /// Returned index is the position of the first character of child's text representation within
+    /// the text representation of this AST node.
     pub fn child_offset(&self, child:&Ast) -> FallibleResult<Index> {
         let searched_token  = Token::Ast(&child);
         let mut found_child = false;

--- a/src/rust/ide/lib/ast/impl/src/lib.rs
+++ b/src/rust/ide/lib/ast/impl/src/lib.rs
@@ -804,7 +804,7 @@ pub trait TokenConsumer {
 }
 
 impl<F:FnMut(Token)> TokenConsumer for F {
-    fn feed(&mut self, val: Token) {
+    fn feed(&mut self, val:Token) {
         self(val)
     }
 }

--- a/src/rust/ide/src/double_representation/module.rs
+++ b/src/rust/ide/src/double_representation/module.rs
@@ -202,6 +202,12 @@ impl Info {
     }
 }
 
+impl From<known::Module> for Info {
+    fn from(ast:known::Module) -> Self {
+        Info {ast}
+    }
+}
+
 
 
 // ==============
@@ -267,6 +273,11 @@ pub fn lookup_method
     }
 
     Err(CannotFindMethod(method.clone()).into())
+}
+
+pub fn definition_span(ast:&known::Module, id:&definition::Id) -> FallibleResult<data::text::Span> {
+    let location = locate(ast,id)?;
+    ast.span_of_descendent_at(&location.crumbs)
 }
 
 impl DefinitionProvider for known::Module {
@@ -381,4 +392,39 @@ mod tests {
 
         expect_not_found("bar a b = a + b");
     }
+
+
+    #[test]
+    fn test_definition_location() {
+        let code = r"
+some def =
+    first line
+    second line
+
+other def =
+    first line
+    second line
+    nested def =
+        nested body
+    last line of other def
+
+last def = inline expression";
+
+        let parser = parser::Parser::new_or_panic();
+        let module = parser.parse_module(code,default()).unwrap();
+        let module   = Info {ast:module};
+
+        let id       = definition::Id::new_plain_name("other");
+        let span     = definition_span(&module.ast,&id).unwrap();
+        assert!(code[span].ends_with("last line of other def\n"));
+
+        let id       = definition::Id::new_plain_name("last");
+        let span     = definition_span(&module.ast,&id).unwrap();
+        assert!(code[span].ends_with("inline expression"));
+
+        let id       = definition::Id::new_plain_names(&["other","nested"]);
+        let span     = definition_span(&module.ast,&id).unwrap();
+        assert!(code[span].ends_with("nested body"));
+    }
+
 }

--- a/src/rust/ide/src/double_representation/module.rs
+++ b/src/rust/ide/src/double_representation/module.rs
@@ -275,6 +275,7 @@ pub fn lookup_method
     Err(CannotFindMethod(method.clone()).into())
 }
 
+/// Get a span in module's text representation where the given definition is located.
 pub fn definition_span(ast:&known::Module, id:&definition::Id) -> FallibleResult<data::text::Span> {
     let location = locate(ast,id)?;
     ast.span_of_descendent_at(&location.crumbs)
@@ -394,7 +395,7 @@ mod tests {
     }
 
 
-    #[test]
+    #[wasm_bindgen_test]
     fn test_definition_location() {
         let code = r"
 some def =

--- a/src/rust/ide/src/double_representation/text.rs
+++ b/src/rust/ide/src/double_representation/text.rs
@@ -29,7 +29,7 @@ pub fn apply_code_change_to_id_map(id_map:&mut IdMap, change:&data::text::TextCh
     let non_white     = |c:char| !c.is_whitespace();
     let logger        = logger::disabled::Logger::new("apply_code_change_to_id_map");
     let vector        = &mut id_map.vec;
-    let inserted_size = Size::from(inserted);
+    let inserted_size = Size::from_text(inserted);
 
     info!(logger,"Old code:\n```\n{code}\n```");
     info!(logger,"New code:\n```\n{new_code}\n```");
@@ -82,7 +82,7 @@ pub fn apply_code_change_to_id_map(id_map:&mut IdMap, change:&data::text::TextCh
             if all_spaces(code_between) && inserted_non_white {
                 debug!(logger,"Will extend the node leftwards.");
                 span.extend_left(inserted_size);
-                span.extend_left(Size::from(code_between));
+                span.extend_left(Size::from_text(code_between));
                 trim_front = true;
             }
         } else if span.index >= removed.index {
@@ -109,7 +109,7 @@ pub fn apply_code_change_to_id_map(id_map:&mut IdMap, change:&data::text::TextCh
             let between = &code[Span::from(span.end() .. removed.index)];
             if all_spaces(between) && inserted_non_white {
                 debug!(logger,"Will extend ");
-                span.size += Size::from(between) + inserted_size;
+                span.size += Size::from_text(between) + inserted_size;
                 trim_back = true;
             }
         }
@@ -158,7 +158,7 @@ pub fn apply_code_change_to_id_map(id_map:&mut IdMap, change:&data::text::TextCh
 
 /// Returns the byte length of leading space characters sequence.
 fn spaces_size(itr:impl Iterator<Item=char>) -> Size {
-    Size::new(itr.take_while(|c| *c == ' ').fold(0, |acc, c| acc + c.len_utf8()))
+    Size::new(itr.take_while(|c| *c == ' ').fold(0, |acc, _| acc + 1))
 }
 
 /// Checks if the given string slice contains only space charactesr.

--- a/src/rust/lib/data/src/text.rs
+++ b/src/rust/lib/data/src/text.rs
@@ -578,7 +578,6 @@ mod test {
         assert_eq!(Size::from_text("日本語").value, 3);
         assert_eq!(&"日本語"[Span::from(0..0)],"");
         assert_eq!(&"日本語"[Span::from(0..3)],"日本語");
-        assert_eq!(&"日本語"[Span::from(3..3)],"");
         assert_eq!(&"日本語"[Span::from(0..1)],"日");
         assert_eq!(&"日本語"[Span::from(2..3)],"語");
     }

--- a/src/rust/lib/data/src/text.rs
+++ b/src/rust/lib/data/src/text.rs
@@ -34,6 +34,17 @@ impl Index {
         let slice = &content.as_ref()[..index.value];
         Self::new(slice.chars().count())
     }
+
+    /// Checked subtraction. Computes `self - rhs`, returning `None` if overflow occurred.
+    pub fn checked_sub(self, rhs:Size) -> Option<Self> {
+        self.value.checked_sub(rhs.value).map(Self::new)
+    }
+}
+
+impl Display for Index {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f,"{}",self.value)
+    }
 }
 
 
@@ -68,6 +79,11 @@ impl Size {
         Size {value}
     }
 
+    /// Obtain a size of given string value.
+    pub fn from_text(value:impl AsRef<str>) -> Self {
+        Size::new(value.as_ref().chars().count())
+    }
+
     /// Checks if this is a non-empty size (more than zero elements).
     pub fn non_empty(self) -> bool {
         self.value > 0
@@ -76,6 +92,11 @@ impl Size {
     /// Checks if this is an empty size (zero elements).
     pub fn is_empty(self) -> bool {
         self.value == 0
+    }
+
+    /// Checked subtraction. Computes `self - rhs`, returning `None` if overflow occurred.
+    pub fn checked_sub(self, rhs:Size) -> Option<Self> {
+        self.value.checked_sub(rhs.value).map(Self::new)
     }
 }
 
@@ -108,12 +129,6 @@ impl SubAssign for Size {
 impl Display for Size {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f,"{}",self.value)
-    }
-}
-
-impl From<&str> for Size {
-    fn from(text:&str) -> Self {
-        Size::new(text.chars().count())
     }
 }
 
@@ -150,6 +165,17 @@ impl Span {
     /// Creates a span from zero index with given length.
     pub fn from_beginning(size:Size) -> Self {
         Span {index:Index::new(0), size}
+    }
+
+    /// Get the index of the last character in the span.
+    ///
+    /// If the span is empty or starts at 0, returns `None`.
+    pub fn last(&self) -> Option<Index> {
+        if self.is_empty() {
+            None
+        } else {
+            self.end().checked_sub(Size::new(1))
+        }
     }
 
     /// Get the character after last character of this span.
@@ -219,6 +245,11 @@ impl Span {
     pub fn set_right(&mut self, new_right:Index) {
         self.size = new_right - self.index;
     }
+
+    /// Check if this is an empty span (zero elements).
+    pub fn is_empty(self) -> bool {
+        self.size.is_empty()
+    }
 }
 
 impls! { From + &From <Range<usize>> for Span { |range|
@@ -244,37 +275,19 @@ impl Display for Span {
 impl std::ops::Index<Span> for str {
     type Output = str;
 
-    fn index(&self, index:Span) -> &Self::Output {
-        println!("===\n{}\n===", self);
-        println!("{:?}", index);
+    fn index(&self, span:Span) -> &Self::Output {
         // Note: Unwraps in this method are justified, as OOB access panic is expected behavior
         // for []-style indexing operations.
-        let mut char_indices = self.char_indices();
-        let start_char = char_indices.nth(index.index.value).unwrap();
-        println!("Start: {:?}", start_char);
-        let start = start_char.0;
-        let end   = match index.size.value.checked_sub(1) {
-            Some(0) => start + start_char.1.len_utf8(),
-            Some(i) => {
-                let dd = char_indices.take(i).enumerate().last();
-                println!("i={},DD: {:?}",i,dd);
-
-                // TODO refactor
-
-                let last_character_index = dd.map_or(0,|last_char| last_char.0);
-                if last_character_index + 1 == i {
-                    println!("aa");
-                    (dd.unwrap().1).0 + (dd.unwrap().1).1.len_utf8()
-                // } else if last_character_index == i {
-                //     println!("bb");
-                //     self.len()
-                }  else {
-                    panic!("End index of span {} exceeds the character count {}",index,self.chars().count());
-                }
-            },
-            None => start,
-        };
-        &self[start..end]
+        let mut iter    = self.char_indices();
+        let first       = iter.nth(span.index.value).unwrap();
+        let to_last     = span.last().map(|last| last - span.index);
+        let last_as_nth = to_last.and_then(|i| i.checked_sub(Size::new(1)));
+        let last        = last_as_nth.map_or(first,|nth| iter.nth(nth.value).unwrap());
+        if span.is_empty() {
+            &self[first.0 .. first.0]
+        } else {
+            &self[first.0 .. last.0 + last.1.len_utf8()]
+        }
     }
 }
 
@@ -562,10 +575,11 @@ mod test {
         let str = "zazó黄ć gęślą jaźń";
         assert_eq!(&str[Span::from(2..5)],"zó黄");
         assert_eq!(&str[Span::from(5..5)],"");
-        assert_eq!(Size::from("日本語").value,3);
+        assert_eq!(Size::from_text("日本語").value, 3);
         assert_eq!(&"日本語"[Span::from(0..0)],"");
+        assert_eq!(&"日本語"[Span::from(0..3)],"日本語");
+        assert_eq!(&"日本語"[Span::from(3..3)],"");
         assert_eq!(&"日本語"[Span::from(0..1)],"日");
         assert_eq!(&"日本語"[Span::from(2..3)],"語");
-
     }
 }

--- a/src/rust/lib/data/src/text.rs
+++ b/src/rust/lib/data/src/text.rs
@@ -169,7 +169,7 @@ impl Span {
 
     /// Get the index of the last character in the span.
     ///
-    /// If the span is empty or starts at 0, returns `None`.
+    /// If the span is empty returns `None`.
     pub fn last(&self) -> Option<Index> {
         if self.is_empty() {
             None


### PR DESCRIPTION
### Pull Request Description
Adds utilities to check the position of AST nodes in the text relative to their parents.
Also, fixed a number of byte/codepoint indexing mismatches and added some tests for this (though still coverage could be improved).

`impl std::ops::Index<Span> for str ` still needs more refactoring, will finish this tomorrow.

### Important Notes
<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/main/docs/style-guide/rust.md).
- [x] All code has been tested where possible.
- [ ] All code has been profiled where possible.

