### PR TITLE
Generate HTML Documentation in Suggestion Entries

### DIFF
--- a/src/rust/ide/lib/parser/src/jsclient.rs
+++ b/src/rust/ide/lib/parser/src/jsclient.rs
@@ -61,12 +61,12 @@ extern "C" {
 pub struct Client {}
 
 impl Client {
-    /// Creates a `Client`
+    /// Creates a `Client`.
     pub fn new() -> Result<Client> {
         Ok(Client {})
     }
 
-    /// Parses Enso code with JS-based parser
+    /// Parses Enso code with JS-based parser.
     pub fn parse(&self, program:String, ids:IdMap) -> api::Result<Ast> {
         let ast = || {
             let json_ids = serde_json::to_string(&ids)?;
@@ -77,7 +77,7 @@ impl Client {
         Ok(ast()?)
     }
 
-    /// Parses Enso code with metadata
+    /// Parses Enso code with metadata.
     pub fn parse_with_metadata<M:api::Metadata>
     (&self, program:String) -> api::Result<api::ParsedSourceFile<M>> {
         let result = || {
@@ -88,7 +88,7 @@ impl Client {
         Ok(result()?)
     }
 
-    /// Calls JS doc parser to generate HTML from documented Enso code
+    /// Calls JS doc parser to generate HTML from documented Enso code.
     pub fn generate_html_docs(&self, program:String) -> api::Result<String> {
         let html_code = || {
             let html_code = doc_parser_generate_html_source(program)?;
@@ -97,7 +97,7 @@ impl Client {
         Ok(html_code()?)
     }
 
-    /// Calls JS doc parser to generate HTML from pure doc code w/o Enso's AST
+    /// Calls JS doc parser to generate HTML from pure doc code without Enso's AST.
     pub fn generate_html_doc_pure(&self, code:String) -> api::Result<String> {
         let html_code = || {
             let html_code = doc_parser_generate_html_from_doc(code)?;

--- a/src/rust/ide/lib/parser/src/lib.rs
+++ b/src/rust/ide/lib/parser/src/lib.rs
@@ -165,7 +165,7 @@ impl DocParser {
     }
 
     /// Parses pure documentation code and generates HTML code.
-    /// Will return empty string for empty entry
+    /// Will return empty string for empty entry.
     pub fn generate_html_doc_pure(&self, code:String) -> api::Result<String> {
         self.borrow_mut().generate_html_doc_pure(code)
     }

--- a/src/rust/ide/lib/parser/src/wsclient.rs
+++ b/src/rust/ide/lib/parser/src/wsclient.rs
@@ -227,7 +227,7 @@ impl Client {
         Ok(client)
     }
 
-    /// Sends a request to parser service to parse Enso code
+    /// Sends a request to parser service to parse Enso code.
     pub fn parse(&mut self, program:String, ids:IdMap) -> api::Result<Ast> {
         let request  = Request::ParseRequest {program,ids};
         let response = self.rpc_call::<serde_json::Value>(request)?;
@@ -237,7 +237,7 @@ impl Client {
         }
     }
 
-    /// Sends a request to parser service to parse code with metadata
+    /// Sends a request to parser service to parse code with metadata.
     pub fn parse_with_metadata<M:Metadata>
     (&mut self, program:String) -> api::Result<ParsedSourceFile<M>> {
         let request  = Request::ParseRequestWithMetadata {content:program};
@@ -248,7 +248,7 @@ impl Client {
         }
     }
 
-    /// Sends a request to parser service to generate HTML code from documented Enso code
+    /// Sends a request to parser service to generate HTML code from documented Enso code.
     pub fn generate_html_docs(&mut self, program:String) -> api::Result<String> {
         let request      = Request::DocParserGenerateHtmlSource {program};
         let response_doc = self.rpc_call_doc(request)?;
@@ -258,7 +258,7 @@ impl Client {
         }
     }
 
-    /// Sends a request to parser service to generate HTML code from pure documentation code
+    /// Sends a request to parser service to generate HTML code from pure documentation code.
     pub fn generate_html_doc_pure(&mut self, code:String) -> api::Result<String> {
         let request      = Request::DocParserGenerateHtmlFromDoc {code};
         let response_doc = self.rpc_call_doc(request)?;

--- a/src/rust/ide/src/model/suggestion_database.rs
+++ b/src/rust/ide/src/model/suggestion_database.rs
@@ -50,16 +50,15 @@ impl Entry {
     pub fn from_ls_entry(entry:language_server::types::SuggestionEntry, logger:impl AnyLogger)
         -> FallibleResult<Self> {
         use language_server::types::SuggestionEntry::*;
-        let convert_doc = |documentation| match documentation {
-            Some(doc) => match Entry::gen_doc(doc) {
+        let convert_doc = |documentation: Option<String>| documentation.and_then({ |doc|
+            match Entry::gen_doc(doc) {
                 Ok(d)  => Some(d),
                 Err(err) => {
                     error!(logger,"Doc parser error: {err}");
                     None
                 },
-            },
-            None => None
-        };
+            }
+        });
         let this = match entry {
             Atom {name,module,arguments,return_type,documentation} => Self {
                     name,arguments,return_type,

--- a/src/rust/ide/src/model/suggestion_database.rs
+++ b/src/rust/ide/src/model/suggestion_database.rs
@@ -55,8 +55,11 @@ impl Entry {
                     module        : module.try_into()?,
                     self_type     : None,
                     documentation : match documentation {
-                        Some(doc) => Some(Entry::gen_doc(doc)?),
-                        None      => None
+                        Some(doc) => match Entry::gen_doc(doc) {
+                            Ok(d)  => Some(d),
+                            Err(_) => None
+                        },
+                        None => None
                     },
                     kind          : EntryKind::Atom,
                 },
@@ -65,8 +68,11 @@ impl Entry {
                     module        : module.try_into()?,
                     self_type     : Some(self_type),
                     documentation : match documentation {
-                        Some(doc) => Some(Entry::gen_doc(doc)?),
-                        None      => None
+                        Some(doc) => match Entry::gen_doc(doc) {
+                            Ok(d)  => Some(d),
+                            Err(_) => None
+                        },
+                        None => None
                     },
                     kind          : EntryKind::Method,
                 },

--- a/src/rust/ide/src/model/suggestion_database.rs
+++ b/src/rust/ide/src/model/suggestion_database.rs
@@ -50,14 +50,12 @@ impl Entry {
     pub fn from_ls_entry(entry:language_server::types::SuggestionEntry, logger:impl AnyLogger)
         -> FallibleResult<Self> {
         use language_server::types::SuggestionEntry::*;
-        let convert_doc = |documentation: Option<String>| documentation.and_then({ |doc|
-            match Entry::gen_doc(doc) {
-                Ok(d)  => Some(d),
-                Err(err) => {
-                    error!(logger,"Doc parser error: {err}");
-                    None
-                },
-            }
+        let convert_doc = |doc: Option<String>| doc.and_then(|doc| match Entry::gen_doc(doc) {
+            Ok(d)  => Some(d),
+            Err(err) => {
+                error!(logger,"Doc parser error: {err}");
+                None
+            },
         });
         let this = match entry {
             Atom {name,module,arguments,return_type,documentation} => Self {

--- a/src/rust/ide/src/model/suggestion_database.rs
+++ b/src/rust/ide/src/model/suggestion_database.rs
@@ -264,7 +264,7 @@ mod test {
             module        : "TestProject.TestModule".to_string(),
             arguments     : vec![],
             return_type   : "TestAtom".to_string(),
-            documentation : None
+            documentation : Some("Test *Atom*".to_string())
         };
         let db_entry = SuggestionsDatabaseEntry {id:12, suggestion:entry};
         let response = language_server::response::GetSuggestionDatabase {
@@ -272,8 +272,14 @@ mod test {
             current_version : 456
         };
         let db = SuggestionDatabase::from_ls_response(response);
+        let response_doc =
+            "<html><head><meta http-equiv=\"Content-Type\" content=\"text/html\" charset=\"UTF-8\" \
+            /><link rel=\"stylesheet\" href=\"style.css\" /><title></title></head><body><div class=\
+            \"Doc\"><div class=\"Synopsis\"><div class=\"Raw\">Test <b>Atom</b></div></div></div>\
+            </body></html>";
         assert_eq!(db.entries.borrow().len(), 1);
         assert_eq!(*db.get(12).unwrap().name, "TextAtom".to_string());
+        assert_eq!(db.get(12).unwrap().documentation, Some(response_doc.to_string()));
         assert_eq!(db.version.get(), 456);
     }
 

--- a/src/rust/ide/src/model/suggestion_database.rs
+++ b/src/rust/ide/src/model/suggestion_database.rs
@@ -7,11 +7,11 @@ use crate::double_representation::module::QualifiedName;
 use enso_protocol::language_server;
 use language_server::types::SuggestionsDatabaseVersion;
 use language_server::types::SuggestionDatabaseUpdateEvent;
+use parser::DocParser as DocParser;
 
 pub use language_server::types::SuggestionEntryArgument as Argument;
 pub use language_server::types::SuggestionEntryId as EntryId;
 pub use language_server::types::SuggestionsDatabaseUpdate as Update;
-pub use parser::DocParser as DocParser;
 
 
 // =============
@@ -53,18 +53,18 @@ impl Entry {
             SuggestionEntryAtom {name,module,arguments,return_type,documentation} =>
                 Self {
                     name,arguments,return_type,
-                    module    : module.try_into()?,
-                    self_type : None,
-                    documentation: Entry::gen_doc(documentation),
-                    kind      : EntryKind::Atom,
+                    module        : module.try_into()?,
+                    self_type     : None,
+                    documentation : Entry::gen_doc(documentation),
+                    kind          : EntryKind::Atom,
                 },
             SuggestionEntryMethod {name,module,arguments,self_type,return_type,documentation} =>
                 Self {
                     name,arguments,return_type,
-                    module    : module.try_into()?,
-                    self_type : Some(self_type),
-                    documentation: Entry::gen_doc(documentation),
-                    kind      : EntryKind::Method,
+                    module        : module.try_into()?,
+                    self_type     : Some(self_type),
+                    documentation : Entry::gen_doc(documentation),
+                    kind          : EntryKind::Method,
                 },
             SuggestionEntryFunction {name,module,arguments,return_type,..} =>
                 Self {
@@ -102,7 +102,7 @@ impl Entry {
         Self {name:name.into(),..self}
     }
 
-    /// Generates HTML documentation for documented suggestion
+    /// Generates HTML documentation for documented suggestion.
     fn gen_doc(doc: Option<String>) -> Option<String> {
         match doc {
             Some(d) => {
@@ -113,7 +113,7 @@ impl Entry {
                     Err(_)     => None,
                 }
             },
-            None    => None,
+            None => None,
         }
     }
 }
@@ -215,6 +215,12 @@ mod test {
     use super::*;
 
     use enso_protocol::language_server::SuggestionsDatabaseEntry;
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+    use wasm_bindgen_test::wasm_bindgen_test;
+
+
+
+    wasm_bindgen_test_configure!(run_in_browser);
 
 
 
@@ -247,7 +253,7 @@ mod test {
         assert_eq!(module_method_entry.code_to_insert(), "Main.moduleMethod".to_string());
     }
 
-    #[test]
+    #[wasm_bindgen_test]
     fn initialize_database() {
         // Empty db
         let response = language_server::response::GetSuggestionDatabase {

--- a/src/rust/ide/src/model/suggestion_database.rs
+++ b/src/rust/ide/src/model/suggestion_database.rs
@@ -7,7 +7,7 @@ use crate::double_representation::module::QualifiedName;
 use enso_protocol::language_server;
 use language_server::types::SuggestionsDatabaseVersion;
 use language_server::types::SuggestionDatabaseUpdatesEvent;
-use parser::DocParser as DocParser;
+use parser::DocParser;
 
 pub use language_server::types::SuggestionEntryArgument as Argument;
 pub use language_server::types::SuggestionEntryId as EntryId;

--- a/src/rust/ide/src/model/suggestion_database.rs
+++ b/src/rust/ide/src/model/suggestion_database.rs
@@ -51,7 +51,7 @@ impl Entry {
         -> FallibleResult<Self> {
         use language_server::types::SuggestionEntry::*;
         let convert_doc = |doc: Option<String>| doc.and_then(|doc| match Entry::gen_doc(doc) {
-            Ok(d)  => Some(d),
+            Ok(d)    => Some(d),
             Err(err) => {
                 error!(logger,"Doc parser error: {err}");
                 None

--- a/src/rust/ide/src/model/suggestion_database.rs
+++ b/src/rust/ide/src/model/suggestion_database.rs
@@ -54,14 +54,20 @@ impl Entry {
                     name,arguments,return_type,
                     module        : module.try_into()?,
                     self_type     : None,
-                    documentation : Entry::gen_doc(documentation),
+                    documentation : match documentation {
+                        Some(doc) => Some(Entry::gen_doc(doc)?),
+                        None      => None
+                    },
                     kind          : EntryKind::Atom,
                 },
             Method {name,module,arguments,self_type,return_type,documentation} => Self {
                     name,arguments,return_type,
                     module        : module.try_into()?,
                     self_type     : Some(self_type),
-                    documentation : Entry::gen_doc(documentation),
+                    documentation : match documentation {
+                        Some(doc) => Some(Entry::gen_doc(doc)?),
+                        None      => None
+                    },
                     kind          : EntryKind::Method,
                 },
             Function {name,module,arguments,return_type,..} => Self {
@@ -101,18 +107,10 @@ impl Entry {
     }
 
     /// Generates HTML documentation for documented suggestion.
-    fn gen_doc(doc: Option<String>) -> Option<String> {
-        match doc {
-            Some(d) => {
-                let parser = DocParser::new_or_panic();
-                let output = parser.generate_html_doc_pure(d);
-                match output {
-                    Ok(result) => Some(result),
-                    Err(_)     => None,
-                }
-            },
-            None => None,
-        }
+    fn gen_doc(doc: String) -> FallibleResult<String> {
+        let parser = DocParser::new()?;
+        let output = parser.generate_html_doc_pure(doc);
+        Ok(output?)
     }
 }
 


### PR DESCRIPTION
### Pull Request Description
closes #682 
Finally, the Documentation Parser and Generator is used somewhere (Yayyy 🎉 🎉 🎉 )
Modifies docstring from suggestion database to HTML code, enabling us to present documentation for nodes in searcher

### Important Notes
<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [ ] All code conforms to the [Rust](https://github.com/luna/enso/blob/main/docs/style-guide/rust.md).
- [ ] All code has been tested where possible.
- [ ] All code has been profiled where possible.

