### PR TITLE
Searcher Controller has access to Executed Graph

### DIFF
--- a/build/run.js
+++ b/build/run.js
@@ -127,7 +127,7 @@ commands.build.rust = async function(argv) {
 
         console.log('Checking the resulting WASM size.')
         let stats = fss.statSync(paths.dist.wasm.mainOptGz)
-        let limit = 3.58
+        let limit = 3.59
         let size = Math.round(100 * stats.size / 1024 / 1024) / 100
         if (size > limit) {
             throw(`Output file size exceeds the limit (${size}MB > ${limit}MB).`)

--- a/src/rust/ide/lib/enso-protocol/src/language_server.rs
+++ b/src/rust/ide/lib/enso-protocol/src/language_server.rs
@@ -151,7 +151,7 @@ trait API {
     #[MethodInput=CompletionInput,rpc_name="search/completion"]
     fn completion
     ( &self
-    , module      : String
+    , module      : Path
     , position    : Position
     , self_type   : Option<String>
     , return_type : Option<String>

--- a/src/rust/ide/src/controller/graph.rs
+++ b/src/rust/ide/src/controller/graph.rs
@@ -401,6 +401,7 @@ impl EndpointInfo {
 /// Handle providing graph controller interface.
 #[derive(Clone,CloneRef,Debug)]
 pub struct Handle {
+    /// Identifier of the graph accessed through this controller.
     pub id     : Rc<Id>,
     /// Model of the module which this graph belongs to.
     pub module : model::Module,
@@ -783,19 +784,20 @@ pub mod tests {
         /// node.
         pub fn new() -> Self {
             MockData {
-                module_path  : model::module::Path::from_mock_module_name("Main"),
-                graph_id     : Id::new_plain_name("main"),
-                project_name : "MockProject".to_string(),
-                code         : "main = 2 + 2".to_string(),
+                module_path  : crate::test::mock::data::module_path(),
+                graph_id     : crate::test::mock::data::graph_id(),
+                project_name : crate::test::mock::data::PROJECT_NAME.to_owned(),
+                code         : crate::test::mock::data::CODE.to_owned(),
             }
         }
 
         /// Creates a mock data with the main function being an inline definition.
         ///
         /// The single node's expression is taken as the argument.
-        pub fn new_inline(main_body:impl Into<String>) -> Self {
+        pub fn new_inline(main_body:impl AsRef<str>) -> Self {
+            let definition_name = crate::test::mock::data::DEFINITION_NAME;
             MockData {
-                code : format!("main = {}", main_body.into()),
+                code : format!("{} = {}",definition_name,main_body.as_ref()),
                 ..Self::new()
             }
         }

--- a/src/rust/ide/src/controller/graph.rs
+++ b/src/rust/ide/src/controller/graph.rs
@@ -401,10 +401,10 @@ impl EndpointInfo {
 /// Handle providing graph controller interface.
 #[derive(Clone,CloneRef,Debug)]
 pub struct Handle {
+    pub id     : Rc<Id>,
     /// Model of the module which this graph belongs to.
     pub module : model::Module,
     parser     : Parser,
-    id         : Rc<Id>,
     logger     : Logger,
 }
 

--- a/src/rust/ide/src/controller/graph.rs
+++ b/src/rust/ide/src/controller/graph.rs
@@ -764,6 +764,7 @@ pub mod tests {
     use ast::test_utils::expect_shape;
     use data::text::Index;
     use data::text::TextChange;
+    use enso_protocol::language_server::MethodPointer;
     use parser::Parser;
     use utils::test::ExpectTuple;
     use wasm_bindgen_test::wasm_bindgen_test;
@@ -814,6 +815,10 @@ pub mod tests {
             let module = self.module_data().plain(&parser);
             let id     = self.graph_id.clone();
             Handle::new(logger,module,parser,id).unwrap()
+        }
+
+        pub fn method(&self) -> MethodPointer {
+            self.module_path.method_pointer(self.graph_id.to_string())
         }
     }
 

--- a/src/rust/ide/src/controller/graph/executed.rs
+++ b/src/rust/ide/src/controller/graph/executed.rs
@@ -219,15 +219,6 @@ pub mod tests {
     }
 
     impl MockData {
-        // pub fn controller1(&self) -> Handle {
-        //     let parser = parser::Parser::new_or_panic();
-        //     let method = self.graph.method();
-        //     let project = Rc::new(model::project::MockAPI::new());
-        //     let ctx = Rc::new(self.ctx.create());
-        //     println!("Method is: {:?}",method);
-        //     Handle::new_internal(graph,project,ctx)
-        // }
-
         pub fn controller(&self) -> Handle {
             let parser      = parser::Parser::new_or_panic();
             let module      = self.module.plain(&parser);

--- a/src/rust/ide/src/controller/graph/executed.rs
+++ b/src/rust/ide/src/controller/graph/executed.rs
@@ -199,7 +199,7 @@ impl Handle {
 // ============
 
 #[cfg(test)]
-mod tests {
+pub mod tests {
     use super::*;
 
     use crate::executor::test_utils::TestWithLocalPoolExecutor;
@@ -210,6 +210,39 @@ mod tests {
     use wasm_bindgen_test::wasm_bindgen_test_configure;
 
     wasm_bindgen_test_configure!(run_in_browser);
+
+    #[derive(Debug,Default)]
+    pub struct MockData {
+        pub graph  : controller::graph::tests::MockData,
+        pub module : model::module::test::MockData,
+        pub ctx    : model::execution_context::plain::test::MockData,
+    }
+
+    impl MockData {
+        // pub fn controller1(&self) -> Handle {
+        //     let parser = parser::Parser::new_or_panic();
+        //     let method = self.graph.method();
+        //     let project = Rc::new(model::project::MockAPI::new());
+        //     let ctx = Rc::new(self.ctx.create());
+        //     println!("Method is: {:?}",method);
+        //     Handle::new_internal(graph,project,ctx)
+        // }
+
+        pub fn controller(&self) -> Handle {
+            let parser      = parser::Parser::new_or_panic();
+            let module      = self.module.plain(&parser);
+            let method      = self.graph.method();
+            let mut project = model::project::MockAPI::new();
+            let ctx         = Rc::new(self.ctx.create());
+            model::project::test::expect_parser(&mut project,&parser);
+            model::project::test::expect_module(&mut project,module);
+            model::project::test::expect_execution_ctx(&mut project,ctx);
+
+            let project = Rc::new(project);
+            Handle::new(Logger::default(),project.clone_ref(),method).boxed_local().expect_ok()
+        }
+
+    }
 
     // Test that checks that value computed notification is properly relayed by the executed graph.
     #[wasm_bindgen_test]

--- a/src/rust/ide/src/controller/searcher.rs
+++ b/src/rust/ide/src/controller/searcher.rs
@@ -359,7 +359,7 @@ impl Searcher {
         let definition_ast = graph.graph_definition_info()?.body().item.clone_ref();
         let self_type      = None;
         let def_span       = double_representation::module::definition_span(&module_ast,&graph_id)?;
-        let position       = TextLocation::convert_span(definition_ast.repr(),&def_span).end.into();
+        let position       = TextLocation::convert_span(module_ast.repr(),&def_span).end.into();
         let request        = ls.completion(&file,&position,&self_type,&return_type,&tags);
         let data           = self.data.clone_ref();
         let database       = self.database.clone_ref();
@@ -390,6 +390,7 @@ impl Searcher {
         Ok(())
     }
 }
+
 
 
 // =============
@@ -468,9 +469,11 @@ mod test {
                 current_version: default(),
             };
 
+            let file_end          = data.module.code.chars().count();
+            let expected_location = TextLocation {line:0, column:file_end};
             expect_call!(client.completion(
                 module      = data.module.path.file_path().clone(),
-                position    = TextLocation {line:0, column:5}.into(), // TODO should be something else likely
+                position    = expected_location.into(),
                 self_type   = None,
                 return_type = None,
                 tag         = None

--- a/src/rust/ide/src/controller/searcher.rs
+++ b/src/rust/ide/src/controller/searcher.rs
@@ -8,7 +8,7 @@ use data::text::TextLocation;
 use enso_protocol::language_server;
 use flo_stream::Subscriber;
 use parser::Parser;
-use enso_protocol::language_server::MethodPointer;
+
 
 
 // =======================
@@ -236,7 +236,7 @@ impl Searcher {
     pub async fn new
     ( parent   : impl AnyLogger
     , project  : &model::Project
-    , method   : MethodPointer
+    , method   : language_server::MethodPointer
     ) -> FallibleResult<Self> {
         let graph = controller::ExecutedGraph::new(&parent,project.clone_ref(),method).await?;
         Ok(Self::new_from_graph_controller(parent,project,graph))

--- a/src/rust/ide/src/executor/test_utils.rs
+++ b/src/rust/ide/src/executor/test_utils.rs
@@ -90,6 +90,8 @@ impl TestWithLocalPoolExecutor {
 impl Drop for TestWithLocalPoolExecutor {
     fn drop(&mut self) {
         // We should be able to finish test.
-        self.expect_finished();
+        if !std::thread::panicking() {
+            self.expect_finished();
+        }
     }
 }

--- a/src/rust/ide/src/lib.rs
+++ b/src/rust/ide/src/lib.rs
@@ -21,15 +21,16 @@
 #![warn(missing_debug_implementations)]
 
 pub mod config;
+pub mod constants;
 pub mod controller;
 pub mod double_representation;
 pub mod executor;
+pub mod ide;
 pub mod model;
 pub mod notification;
+pub mod test;
 pub mod transport;
 pub mod view;
-pub mod constants;
-pub mod ide;
 
 pub use crate::ide::IdeInitializer;
 

--- a/src/rust/ide/src/model/execution_context/plain.rs
+++ b/src/rust/ide/src/model/execution_context/plain.rs
@@ -184,7 +184,6 @@ pub mod test {
     use super::*;
 
     use crate::double_representation::definition::DefinitionName;
-    use crate::constants::DEFAULT_PROJECT_NAME;
 
     #[derive(Clone,Derivative)]
     #[derivative(Debug)]
@@ -205,9 +204,9 @@ pub mod test {
         pub fn new() -> MockData {
             MockData {
                 context_id      : model::execution_context::Id::new_v4(),
-                module_path     : model::module::Path::from_mock_module_name("Test"),
-                root_definition : DefinitionName::new_plain("main"),
-                project_name    : DEFAULT_PROJECT_NAME.to_string(),
+                module_path     : crate::test::mock::data::module_path(),
+                root_definition : crate::test::mock::data::definition_name(),
+                project_name    : crate::test::mock::data::PROJECT_NAME.to_owned(),
             }
         }
 

--- a/src/rust/ide/src/model/module.rs
+++ b/src/rust/ide/src/model/module.rs
@@ -378,8 +378,8 @@ pub mod test {
     impl Default for MockData {
         fn default() -> Self {
             Self {
-                path     : Path::from_mock_module_name("Main"),
-                code     : "main = 2 + 2".into(),
+                path     : crate::test::mock::data::module_path(),
+                code     : crate::test::mock::data::CODE.to_owned(),
                 id_map   : default(),
                 metadata : default(),
             }

--- a/src/rust/ide/src/model/project.rs
+++ b/src/rust/ide/src/model/project.rs
@@ -100,8 +100,7 @@ pub mod test {
     pub fn expect_execution_ctx(project:&mut MockAPI, ctx:model::ExecutionContext) {
         let ctx2 = ctx.clone_ref();
         project.expect_create_execution_context()
-            // TODO below "with" limitation should be restored as the usage is fixed
-            // .withf_st    (move |root_definition| root_definition == &ctx.current_method())
+            .withf_st    (move |root_definition| dbg!(root_definition) == dbg!(&ctx.current_method()))
             .returning_st(move |_root_definition| ready(Ok(ctx2.clone_ref())).boxed_local());
     }
 }

--- a/src/rust/ide/src/model/project.rs
+++ b/src/rust/ide/src/model/project.rs
@@ -80,6 +80,8 @@ pub type Synchronized = synchronized::Project;
 pub mod test {
     use super::*;
 
+    use futures::future::ready;
+
     /// Sets up parser expectation on the mock project.
     pub fn expect_parser(project:&mut MockAPI, parser:&Parser) {
         let parser = parser.clone_ref();
@@ -91,6 +93,15 @@ pub mod test {
         let module_path = module.path().clone_ref();
         project.expect_module()
             .withf_st    (move |path| path == &module_path)
-            .returning_st(move |_path| futures::future::ready(Ok(module.clone_ref())).boxed_local());
+            .returning_st(move |_path| ready(Ok(module.clone_ref())).boxed_local());
+    }
+
+    /// Sets up module expectation on the mock project, returning a give module.
+    pub fn expect_execution_ctx(project:&mut MockAPI, ctx:model::ExecutionContext) {
+        let ctx2 = ctx.clone_ref();
+        project.expect_create_execution_context()
+            // TODO below "with" limitation should be restored as the usage is fixed
+            // .withf_st    (move |root_definition| root_definition == &ctx.current_method())
+            .returning_st(move |_root_definition| ready(Ok(ctx2.clone_ref())).boxed_local());
     }
 }

--- a/src/rust/ide/src/model/project.rs
+++ b/src/rust/ide/src/model/project.rs
@@ -100,7 +100,7 @@ pub mod test {
     pub fn expect_execution_ctx(project:&mut MockAPI, ctx:model::ExecutionContext) {
         let ctx2 = ctx.clone_ref();
         project.expect_create_execution_context()
-            .withf_st    (move |root_definition| dbg!(root_definition) == dbg!(&ctx.current_method()))
+            .withf_st    (move |root_definition| root_definition == &ctx.current_method())
             .returning_st(move |_root_definition| ready(Ok(ctx2.clone_ref())).boxed_local());
     }
 }

--- a/src/rust/ide/src/test.rs
+++ b/src/rust/ide/src/test.rs
@@ -1,17 +1,19 @@
 //! Module for support code for writing tests.
 
 //! Utilities for mocking IDE components.
+#[cfg(test)]
 pub mod mock {
     //! Data used to create mock IDE components.
     //!
-    //! Contains a number of constants, so different parts of tests that mock different models use
+    //! Contains a number of constants and functions building more complex structures from them.
+    //! The purpose is to allow different parts of tests that mock different models using
     //! consistent data.
     #[allow(missing_docs)]
     pub mod data {
-        pub const PROJECT_NAME:&str = "MockProject";
-        pub const MODULE_NAME:&str = "Mock_Module";
-        pub const CODE:&str = "main = 2 + 2";
-        pub const DEFINITION_NAME:&str = "main";
+        pub const PROJECT_NAME    : &str = "MockProject";
+        pub const MODULE_NAME     : &str = "Mock_Module";
+        pub const CODE            : &str = "main = 2 + 2";
+        pub const DEFINITION_NAME : &str = "main";
 
         pub fn module_path() -> crate::model::module::Path {
             crate::model::module::Path::from_mock_module_name(MODULE_NAME)

--- a/src/rust/ide/src/test.rs
+++ b/src/rust/ide/src/test.rs
@@ -1,0 +1,28 @@
+//! Module for support code for writing tests.
+
+//! Utilities for mocking IDE components.
+pub mod mock {
+    //! Data used to create mock IDE components.
+    //!
+    //! Contains a number of constants, so different parts of tests that mock different models use
+    //! consistent data.
+    #[allow(missing_docs)]
+    pub mod data {
+        pub const PROJECT_NAME:&str = "MockProject";
+        pub const MODULE_NAME:&str = "Mock_Module";
+        pub const CODE:&str = "main = 2 + 2";
+        pub const DEFINITION_NAME:&str = "main";
+
+        pub fn module_path() -> crate::model::module::Path {
+            crate::model::module::Path::from_mock_module_name(MODULE_NAME)
+        }
+
+        pub fn definition_name() -> crate::double_representation::definition::DefinitionName {
+            crate::double_representation::definition::DefinitionName::new_plain(DEFINITION_NAME)
+        }
+
+        pub fn graph_id() -> crate::double_representation::graph::Id {
+            crate::double_representation::graph::Id::new_plain_name(DEFINITION_NAME)
+        }
+    }
+}

--- a/src/rust/ide/src/view/node_editor.rs
+++ b/src/rust/ide/src/view/node_editor.rs
@@ -822,11 +822,6 @@ impl NodeEditor {
         info!(self.logger, "Initialized.");
         Ok(self)
     }
-
-    /// The path to the module, which graph is currently displayed.
-    pub fn displayed_module(&self) -> model::module::Path {
-        self.graph.model.controller.graph().module.path().clone_ref()
-    }
 }
 
 impl display::Object for NodeEditor {

--- a/src/rust/ide/src/view/node_searcher.rs
+++ b/src/rust/ide/src/view/node_searcher.rs
@@ -9,7 +9,6 @@ use crate::model::module::NodeMetadata;
 use crate::model::module::Position;
 use crate::view::node_editor::NodeEditor;
 
-use data::text::TextLocation;
 use ensogl::data::color;
 use ensogl::display;
 use ensogl::display::Scene;
@@ -89,12 +88,8 @@ impl NodeSearcher {
             self.display_object.add_child(&self.text_field.display_object());
             self.text_field.clear_content();
             self.text_field.set_focus();
-            let module     = self.node_editor.displayed_module();
-            //TODO[ao]: Now we use some predefined location, until this task will be done:
-            // https://github.com/enso-org/ide/issues/653 . This code should be replaced with
-            // the proper Searcher view integration anyway.
-            let position   = TextLocation { line:2, column:4 };
-            let controller = controller::Searcher::new(&self.logger,&self.project,module,position);
+            let graph      = self.node_editor.graph.controller().clone_ref();
+            let controller = controller::Searcher::new_from_graph_controller(&self.logger,&self.project,graph);
             let logger     = self.logger.clone_ref();
             let weak       = Rc::downgrade(&self.controller);
             executor::global::spawn(controller.subscribe().for_each(move |notification| {

--- a/src/rust/lib/data/src/text.rs
+++ b/src/rust/lib/data/src/text.rs
@@ -396,6 +396,13 @@ impl TextLocation {
         Self::from_index(content,range.start)..Self::from_index(content,range.end)
     }
 
+    /// Converts a span into a range of TextLocation. It iterates over all characters before range's
+    /// end.
+    pub fn convert_span(content:impl Str, span:&Span) -> Range<Self> {
+        let range = span.index..span.end();
+        Self::convert_range(content,&range)
+    }
+
     /// Converts a range in bytes into a range of TextLocation. It iterates over all characters
     /// before range's end.
     pub fn convert_byte_range(content:impl Str, range:&Range<ByteIndex>) -> Range<Self> {


### PR DESCRIPTION
### Pull Request Description
This PR adds access to the executed graph to the searcher controller. This will be used by a few different tasks, like #611 or #609. 

### Important Notes
<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/main/docs/style-guide/rust.md).
- [x] All code has been tested where possible.
- [ ] All code has been profiled where possible.

