### PR TITLE
AST update

### DIFF
--- a/build/run.js
+++ b/build/run.js
@@ -127,7 +127,7 @@ commands.build.rust = async function(argv) {
 
         console.log('Checking the resulting WASM size.')
         let stats = fss.statSync(paths.dist.wasm.mainOptGz)
-        let limit = 3.60
+        let limit = 3.61
         let size = Math.round(100 * stats.size / 1024 / 1024) / 100
         if (size > limit) {
             throw(`Output file size exceeds the limit (${size}MB > ${limit}MB).`)

--- a/src/rust/ide/lib/ast/impl/src/lib.rs
+++ b/src/rust/ide/lib/ast/impl/src/lib.rs
@@ -500,12 +500,16 @@ pub enum Shape<T> {
                   , paths    : Tree<Ast, Unit>                         },
 
     // === Spaceless AST ===
-    Comment       (Comment),
-    Import        (Import<T>),
-    Mixfix        (Mixfix<T>),
-    Group         (Group<T>),
-    Def           (Def<T>),
-    Foreign       (Foreign),
+    Comment        (Comment),
+    Import         (Import<T>),
+    JavaImport     (JavaImport<T>),
+    Mixfix         (Mixfix<T>),
+    Group          (Group<T>),
+    SequenceLiteral(SequenceLiteral<T>),
+    TypesetLiteral (TypesetLiteral<T>),
+    Def            (Def<T>),
+    Foreign        (Foreign),
+    Modified       (Modified<T>),
 }
 
 /// Macrot that calls its argument (possibly other macro
@@ -757,6 +761,10 @@ pub enum MacroPatternMatchRaw<T> {
     pub path:T
 }
 
+#[ast] pub struct JavaImport<T> {
+    pub path:Vec<T>,
+}
+
 #[ast] pub struct Mixfix<T> {
     pub name: Vec<T>,
     pub args: Vec<T>,
@@ -764,6 +772,14 @@ pub enum MacroPatternMatchRaw<T> {
 
 #[ast] pub struct Group<T> {
     pub body: Option<T>,
+}
+
+#[ast] pub struct SequenceLiteral<T> {
+    pub items:Vec<T>,
+}
+
+#[ast] pub struct TypesetLiteral<T> {
+    pub expression:Option<T>,
 }
 
 #[ast] pub struct Def<T> {
@@ -776,6 +792,11 @@ pub enum MacroPatternMatchRaw<T> {
     pub indent : usize,
     pub lang   : String,
     pub code   : Vec<String>
+}
+
+#[ast] pub struct Modified<T> {
+    pub modifier:String,
+    pub definition:T,
 }
 
 

--- a/src/rust/ide/lib/ast/impl/src/repr.rs
+++ b/src/rust/ide/lib/ast/impl/src/repr.rs
@@ -331,10 +331,14 @@ has_tokens!(Ambiguous<T>, self.segs);
 
 spaceless_ast!(Comment);
 spaceless_ast!(Import<T>);
+spaceless_ast!(JavaImport<T>);
 spaceless_ast!(Mixfix<T>);
 spaceless_ast!(Group<T>);
+spaceless_ast!(SequenceLiteral<T>);
+spaceless_ast!(TypesetLiteral<T>);
 spaceless_ast!(Def<T>);
 spaceless_ast!(Foreign);
+spaceless_ast!(Modified<T>);
 
 
 

--- a/src/rust/ide/lib/parser/tests/parsing.rs
+++ b/src/rust/ide/lib/parser/tests/parsing.rs
@@ -360,7 +360,11 @@ impl Fixture {
     /// match node. Node contents is not covered.
     fn deserialize_macro_matches(&mut self) {
         let macro_usages = vec!
-            [ "foo -> bar"
+            [ "[]", "[1,2,3]"
+            , "{x}"
+            , "unsafe x", "private x"
+            , "polyglot java import com.example.MyClass"
+            , "foo -> bar"
             , "()"
             , "(foo -> bar)"
             , "a b c -> bar"


### PR DESCRIPTION
### Pull Request Description
This PR updates spaceless ast shapes to follow current scala implementation.
This prevents IDE from breaking when trying to deserialize them.

### Important Notes
Everything is quasi-provisional, as the parser rewrite is underway.
Still, typing `[1,2,3]` shouldn't break double representation.

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/main/docs/style-guide/rust.md).
- [x] All code has been tested where possible.
- [ ] All code has been profiled where possible.

