### PR TITLE
Fix Minor Bugs with Output Ports

### DIFF
--- a/src/rust/ide/lib/view/src/graph_editor.rs
+++ b/src/rust/ide/lib/view/src/graph_editor.rs
@@ -2339,8 +2339,8 @@ fn new_graph_editor(app:&Application) -> GraphEditor {
         [ cursor_on_drag
         , cursor_selection
         , cursor_press
-        , cursor_style_edge_drag
         , node_cursor_style
+        , cursor_style_edge_drag
         ].fold();
 
     eval cursor_style ((style) cursor.frp.set_style.emit(style));

--- a/src/rust/ide/lib/view/src/graph_editor/component/node/port/output.rs
+++ b/src/rust/ide/lib/view/src/graph_editor/component/node/port/output.rs
@@ -666,20 +666,17 @@ impl OutputPorts {
     /// Set the pattern for which output ports should be presented. Triggers a rebinding of the
     /// internal FRP and updates the shape appearance.
     pub fn set_pattern_span_tree(&self, pattern_span_tree:&SpanTree) {
-
         // === Update data / shapes ===
 
         // We want to be able to match each `PortId` to a `Crumb` from the expression, including
         // the root.
-        let number_of_ports     = 1 + pattern_span_tree.root_ref().leaf_iter().count() as u32;
+        let number_of_ports     = pattern_span_tree.root_ref().leaf_iter().count() as u32;
         let expression_nodes    = pattern_span_tree.root_ref().leaf_iter();
         // Create a `PortId` for every leaf and store them in tuples.
         let port_ids_for_crumbs = expression_nodes.enumerate().map(|(index, node)| {
-            (PortId::new(index + 1), node.crumbs)
+            (PortId::new(index), node.crumbs)
         });
-        let mut id_map = HashMap::<PortId,span_tree::Crumbs>::from_iter(port_ids_for_crumbs);
-        // Also add the root node.
-        id_map.insert(PortId::new(0), pattern_span_tree.root_ref().crumbs);
+        let id_map = HashMap::<PortId,span_tree::Crumbs>::from_iter(port_ids_for_crumbs);
 
         let id_map = id_map;
         *self.id_map.borrow_mut() = id_map;
@@ -697,7 +694,7 @@ impl OutputPorts {
         const TWEEN_END_VALUE:f32 = 1.0;
 
         let delay_show = &self.delay_show;
-        let delay_hide = &self.delay_show;
+        let delay_hide = &self.delay_hide;
 
         let mouse_down = frp.on_port_mouse_down.clone_ref();
         let mouse_over = frp.on_port_mouse_over.clone_ref();


### PR DESCRIPTION
### Pull Request Description
This PR fixes some small issues that appeared after merging the colored-tupes PR.
Three issues are fixed: 
- Output ports where showing one more output port than thy should
- Hovering from one output port to another did not correctly switch the output port
- A minor visual bugfix for updating the color of the cursor when hovering over ports. 


### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/main/docs/style-guide/rust.md).
- [x] All code has been tested where possible.
- [x] All code has been profiled where possible.

