### PR TITLE
Fix visualisation cotnainer not appearing on keyboard input.

### DIFF
--- a/src/rust/ide/lib/view/src/graph_editor.rs
+++ b/src/rust/ide/lib/view/src/graph_editor.rs
@@ -2269,7 +2269,7 @@ fn new_graph_editor(app:&Application) -> GraphEditor {
     viz_tgt_nodes_off    <- viz_tgt_nodes.map(f!([model](node_ids) {
         node_ids.iter().cloned().filter(|node_id| {
             model.nodes.get_cloned_ref(node_id)
-                .map(|node| !node.visualization.is_visible())
+                .map(|node| !node.visualization.is_active())
                 .unwrap_or_default()
         }).collect_vec()
     }));

--- a/src/rust/ide/lib/view/src/graph_editor/component/visualization/container.rs
+++ b/src/rust/ide/lib/view/src/graph_editor/component/visualization/container.rs
@@ -279,8 +279,9 @@ impl ContainerModel {
         self
     }
 
-    /// Indicates whether the visualization is visible.
-    pub fn is_visible(&self) -> bool {
+    /// Indicates whether the visualization container is visible and active.
+    /// Note: can't be called `is_visible` due to a naming conflict with `display::object::class`.
+    pub fn is_active(&self) -> bool {
         self.view.has_parent()
     }
 }
@@ -308,7 +309,7 @@ impl ContainerModel {
     }
 
     fn toggle_visibility(&self) {
-        self.set_visibility(!self.is_visible())
+        self.set_visibility(!self.is_active())
     }
 
     fn set_visualization(&self, visualization:Option<visualization::Instance>) {


### PR DESCRIPTION
### Pull Request Description
Fixes a bug that leads to the visualization container no longer appearing when toggled through the keyboard shortcut.

### Important Notes
Changes the `is_visible` method from the `visualization::Container` to `is_active` to avoid name collision with the `display::object::is_active` method.

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/main/docs/style-guide/rust.md).
- [x] All code has been tested where possible.
- [x] All code has been profiled where possible.

