### PR TITLE
Reenable `.strict()` for yargs parser after macOS Big Sur fix.

### DIFF
--- a/src/js/lib/client/src/index.js
+++ b/src/js/lib/client/src/index.js
@@ -41,11 +41,7 @@ let optParser = yargs
     .help()
     .version(false)
     .parserConfiguration({'populate--':true})
-//  FIXME [MM]
-//  This modifier crashes Enso Studio on macOS 11, To test if it works 
-//  again in next macOS betas - temporarily solves #650
-//  https://github.com/yargs/yargs/issues/1688
-//  .strict()
+    .strict()
 
 
 // === Config Options ===


### PR DESCRIPTION
### Pull Request Description
Reenables `.strict()` for yargs parser after macOS Big Sur fix.

### Important Notes
<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist
Please include the following checklist in your PR:

- [ ] The documentation has been updated if necessary.
- [ ] All code conforms to the [Rust](https://github.com/luna/enso/blob/main/docs/style-guide/rust.md).
- [ ] All code has been tested where possible.
- [ ] All code has been profiled where possible.

