### PR TITLE
Fix white text on light background in searcher

### DIFF
--- a/src/rust/ensogl/lib/theme/src/lib.rs
+++ b/src/rust/ensogl/lib/theme/src/lib.rs
@@ -279,7 +279,7 @@ define_default_theme! { light
                 color = color::Lcha::new(0.55,0.65,0.79,1.0)
             }
             text {
-                color = color::Lcha::new(1.0,0.0,0.0,0.7);
+                color = color::Lcha::new(0.0,0.0,0.0,0.7);
                 selection {
                     color = color::Lcha::new(0.7,0.0,0.125,0.7)
                 }


### PR DESCRIPTION
### Pull Request Description
In some review fixes the text on searcher turn white.

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/main/docs/style-guide/rust.md).
- [x] All code has been tested where possible.
- [x] All code has been profiled where possible.

