### PR TITLE
Wip/ao/vis ptr events

### DIFF
--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -39,7 +39,7 @@ members = [
 ]
 
 [profile.dev]
-opt-level = 2
+opt-level = 0
 lto       = false
 debug     = true
 

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -39,7 +39,7 @@ members = [
 ]
 
 [profile.dev]
-opt-level = 0
+opt-level = 2
 lto       = false
 debug     = true
 

--- a/src/rust/ensogl/lib/core/src/display/scene.rs
+++ b/src/rust/ensogl/lib/core/src/display/scene.rs
@@ -10,6 +10,7 @@ use crate::prelude::*;
 
 use crate::animation;
 use crate::control::callback;
+use crate::control::io::keyboard::listener::KeyboardFrpBindings;
 use crate::control::io::mouse::MouseManager;
 use crate::control::io::mouse;
 use crate::data::color;
@@ -21,21 +22,21 @@ use crate::display::render::RenderComposer;
 use crate::display::render::RenderPipeline;
 use crate::display::scene::dom::DomScene;
 use crate::display::shape::text::glyph::font;
+use crate::display::shape::ShapeSystemInstance;
+use crate::display::shape::system::ShapeSystemOf;
 use crate::display::style;
+use crate::display::style::data::DataMatch;
 use crate::display::symbol::registry::SymbolRegistry;
 use crate::display::symbol::Symbol;
 use crate::display;
 use crate::system::gpu::data::uniform::Uniform;
 use crate::system::gpu::data::uniform::UniformScope;
 use crate::system::gpu::shader::Context;
+use crate::system::web;
 use crate::system::web::NodeInserter;
 use crate::system::web::StyleSetter;
-use crate::system::web;
-use crate::display::shape::ShapeSystemInstance;
-use crate::display::shape::system::ShapeSystemOf;
-use crate::control::io::keyboard::listener::KeyboardFrpBindings;
+use crate::system::web::IgnoreContextMenuHandle;
 
-use display::style::data::DataMatch;
 use enso_frp as frp;
 use std::any::TypeId;
 use web_sys::HtmlElement;
@@ -309,10 +310,8 @@ impl Mouse {
         let body            = web::dom::WithKnownShape::new(&web::document().body().unwrap());
         let mouse_manager   = MouseManager::new_separated(&body.into(),&web::window());
         let frp             = frp::io::Mouse::new();
-        let on_move         = mouse_manager.on_move.add(f!([frp,scene_frp,position,last_position]
-            (event:&mouse::OnMove) {
-                let as_event:&web_sys::Event = event.as_ref();
-                scene_frp.processed_event_source.emit(Some(as_event.clone()));
+        let on_move         = mouse_manager.on_move.add(Self::make_handler(&scene_frp,
+            f!([frp,scene_frp,position,last_position] (event:&mouse::OnMove) {
                 let shape       = scene_frp.shape.value();
                 let pixel_ratio = shape.pixel_ratio as i32;
                 let screen_x    = event.client_x();
@@ -327,21 +326,12 @@ impl Mouse {
                     let position = Vector2(new_pos.x as f32,new_pos.y as f32) - shape.center();
                     frp.position.emit(position);
                 }
-                scene_frp.processed_event_source.emit(None);
             }
-        ));
-        let on_down = mouse_manager.on_down.add(f!([frp,scene_frp](event) {
-            let as_event:&web_sys::Event = event.as_ref();
-            scene_frp.processed_event_source.emit(Some(as_event.clone()));
-            frp.down.emit(event.button());
-            scene_frp.processed_event_source.emit(None);
-        }));
-        let on_up   = mouse_manager.on_up.add(f!([frp,scene_frp](event)  {
-            let as_event:&web_sys::Event = event.as_ref();
-            scene_frp.processed_event_source.emit(Some(as_event.clone()));
-            frp.up.emit(event.button());
-            scene_frp.processed_event_source.emit(None);
-        }));
+        )));
+        let on_down = mouse_manager.on_down.add(Self::make_handler(&scene_frp,
+            f!((event:&mouse::OnDown) frp.down.emit(event.button()))));
+        let on_up   = mouse_manager.on_up.add(Self::make_handler(&scene_frp,
+            f!((event:&mouse::OnUp) frp.up.emit(event.button()))));
         let handles = Rc::new([on_move,on_down,on_up]);
         Self {mouse_manager,last_position,position,hover_ids,target,handles,frp,scene_frp,logger}
     }
@@ -371,6 +361,21 @@ impl Mouse {
         let new_pos  = self.last_position.get();
         let position = Vector2(new_pos.x as f32,new_pos.y as f32) - shape.center();
         self.frp.position.emit(position);
+    }
+
+    /// A helper function for creating mouse event handlers.
+    ///
+    /// This wraps the `processing_fn` so before processing the `current_js_event` in scene FRP is
+    /// set to the received js event, and after processing it is set back to `None`.
+    fn make_handler<JsEvent,Event>
+    (scene_frp:&Frp, mut processing_fn:impl FnMut(&Event)) -> impl FnMut(&Event)
+    where Event   : AsRef<JsEvent>,
+          JsEvent : AsRef<web_sys::Event> {
+        f!([scene_frp] (event) {
+            scene_frp.current_js_event_source.emit(Some(event.as_ref().as_ref().clone()));
+            processing_fn(event);
+            scene_frp.current_js_event_source.emit(None);
+        })
     }
 }
 
@@ -762,48 +767,57 @@ impl Views {
 /// FRP Scene interface.
 #[derive(Clone,CloneRef,Debug)]
 pub struct Frp {
-    pub network                    : frp::Network,
-    pub shape                      : frp::Sampler<Shape>,
-    pub camera_changed             : frp::Stream,
-    pub frame_time                 : frp::Stream<f32>,
-    pub processed_event            : frp::Stream<Option<web_sys::Event>>,
-    pub pass_processed_event_to_js : frp::Source<()>,
-    processed_event_source         : frp::Source<Option<web_sys::Event>>,
-    camera_changed_source          : frp::Source,
-    frame_time_source              : frp::Source<f32>,
+    pub network                      : frp::Network,
+    pub shape                        : frp::Sampler<Shape>,
+    pub camera_changed               : frp::Stream,
+    pub frame_time                   : frp::Stream<f32>,
+    pub current_js_event             : frp::Stream<Option<web_sys::Event>>,
+    /// Emitting this signal while handling js event (`current_js_event` is Some) makes this event
+    /// pass to the DOM elements. Otherwise the js event propagation will be stopped.
+    pub pass_current_js_event_to_dom : frp::Source<()>,
+    camera_changed_source            : frp::Source,
+    frame_time_source                : frp::Source<f32>,
+    current_js_event_source          : frp::Source<Option<web_sys::Event>>,
 }
 
 impl Frp {
     /// Constructor
     pub fn new(shape:&frp::Sampler<Shape>) -> Self {
         frp::new_network! { network
-            camera_changed_source      <- source();
-            frame_time_source          <- source();
-            processed_event_source     <- source();
-            pass_processed_event_to_js <- source();
-            event_is_passed_to_js      <- any(...);
-            event_is_passed_to_js      <+ pass_processed_event_to_js.constant(true);
-            processed_event            <- any(...);
+            camera_changed_source        <- source();
+            frame_time_source            <- source();
+            current_js_event_source      <- source();
+            pass_current_js_event_to_dom <- source();
+            event_is_passed_to_dom       <- any(...);
+            event_is_passed_to_dom       <+ pass_current_js_event_to_dom.constant(true);
+            current_js_event             <- any(...);
 
-            event_is_being_changed <- processed_event_source.map3(&processed_event,&event_is_passed_to_js,
-                |new:&Option<web_sys::Event>, current:&Option<web_sys::Event>, is_passed| {
-                    if let Some(e) = current {
-                        if !is_passed {
-                            e.stop_propagation();
-                        }
-                    }
-                    new.clone()
-                }
-            );
-            event_is_passed_to_js <+ event_is_being_changed.constant(false);
-            processed_event       <+ event_is_being_changed;
+            new_current_js_event <- current_js_event_source.map3
+                (&current_js_event,&event_is_passed_to_dom,Self::on_current_js_event_change);
+            event_is_passed_to_dom <+ new_current_js_event.constant(false);
+            current_js_event       <+ new_current_js_event;
         }
-        let shape           = shape.clone_ref();
-        let camera_changed  = camera_changed_source.clone_ref().into();
-        let frame_time      = frame_time_source.clone_ref().into();
-        let processed_event = processed_event.into();
-        Self {network,shape,camera_changed,frame_time,processed_event,pass_processed_event_to_js,
-            processed_event_source,camera_changed_source,frame_time_source}
+        let shape            = shape.clone_ref();
+        let camera_changed   = camera_changed_source.clone_ref().into();
+        let frame_time       = frame_time_source.clone_ref().into();
+        let current_js_event = current_js_event.into();
+        Self {network,shape,camera_changed,frame_time,current_js_event,pass_current_js_event_to_dom,
+            camera_changed_source,frame_time_source,current_js_event_source}
+    }
+
+    // The bool is passed by reference to match the signatures expected by FRP eval.
+    #[allow(clippy::trivially_copy_pass_by_ref)]
+    fn on_current_js_event_change
+    (new:&Option<web_sys::Event>, current:&Option<web_sys::Event>, is_passed:&bool)
+    -> Option<web_sys::Event> {
+        // Whenever the current js event change, we pass the processed one to the dom if someone
+        // asked to.
+        if let Some(e) = current {
+            if !is_passed {
+                e.stop_propagation();
+            }
+        }
+        new.clone()
     }
 }
 
@@ -839,26 +853,27 @@ impl Extensions {
 
 #[derive(Clone,CloneRef,Debug)]
 pub struct SceneData {
-    pub display_object  : display::object::Instance,
-    pub dom             : Dom,
-    pub context         : Context,
-    pub symbols         : SymbolRegistry,
-    pub variables       : UniformScope,
-    pub mouse           : Mouse,
-    pub keyboard        : Keyboard,
-    pub uniforms        : Uniforms,
-    pub shapes          : ShapeRegistry,
-    pub stats           : Stats,
-    pub dirty           : Dirty,
-    pub logger          : Logger,
-    pub renderer        : Renderer,
-    pub views           : Views,
-    pub style_sheet     : style::Sheet,
-    pub bg_color_var    : style::Var,
-    pub bg_color_change : callback::Handle,
-    pub fonts           : font::SharedRegistry,
-    pub frp             : Frp,
-    extensions          : Extensions,
+    pub display_object   : display::object::Instance,
+    pub dom              : Dom,
+    pub context          : Context,
+    pub symbols          : SymbolRegistry,
+    pub variables        : UniformScope,
+    pub mouse            : Mouse,
+    pub keyboard         : Keyboard,
+    pub uniforms         : Uniforms,
+    pub shapes           : ShapeRegistry,
+    pub stats            : Stats,
+    pub dirty            : Dirty,
+    pub logger           : Logger,
+    pub renderer         : Renderer,
+    pub views            : Views,
+    pub style_sheet      : style::Sheet,
+    pub bg_color_var     : style::Var,
+    pub bg_color_change  : callback::Handle,
+    pub fonts            : font::SharedRegistry,
+    pub frp              : Frp,
+    extensions           : Extensions,
+    disable_context_menu : Rc<IgnoreContextMenuHandle>,
 }
 
 impl SceneData {
@@ -871,35 +886,37 @@ impl SceneData {
         parent_dom.append_child(&dom.root).unwrap();
         dom.recompute_shape_with_reflow();
 
-        let display_object  = display::object::Instance::new(&logger);
-        let context         = web::get_webgl2_context(&dom.layers.canvas);
-        let sub_logger      = Logger::sub(&logger,"shape_dirty");
-        let shape_dirty     = ShapeDirty::new(sub_logger,Box::new(on_mut.clone()));
-        let sub_logger      = Logger::sub(&logger,"symbols_dirty");
-        let dirty_flag      = SymbolRegistryDirty::new(sub_logger,Box::new(on_mut));
-        let on_change       = enclose!((dirty_flag) move || dirty_flag.set());
-        let variables       = UniformScope::new(Logger::sub(&logger,"global_variables"),&context);
-        let symbols         = SymbolRegistry::mk(&variables,&stats,&context,&logger,on_change);
-        let screen_shape    = dom.shape();
-        let width           = screen_shape.width;
-        let height          = screen_shape.height;
-        let symbols_dirty   = dirty_flag;
-        let views           = Views::mk(&logger,width,height);
-        let stats           = stats.clone();
-        let shapes          = ShapeRegistry::default();
-        let uniforms        = Uniforms::new(&variables);
-        let dirty           = Dirty {symbols:symbols_dirty,shape:shape_dirty};
-        let renderer        = Renderer::new(&logger,&dom,&context,&variables);
-        let style_sheet     = style::Sheet::new();
-        let fonts           = font::SharedRegistry::new();
-        let frp             = Frp::new(&dom.root.shape);
-        let mouse_logger    = Logger::sub(&logger,"mouse");
-        let mouse           = Mouse::new(&frp,&variables,mouse_logger);
-        let keyboard        = Keyboard::new();
-        let network         = &frp.network;
-        let extensions      = Extensions::default();
-        let bg_color_var    = style_sheet.var("application . background . color");
-        let bg_color_change = bg_color_var.on_change(f!([dom](change){
+        let display_object       = display::object::Instance::new(&logger);
+        let context              = web::get_webgl2_context(&dom.layers.canvas);
+        let sub_logger           = Logger::sub(&logger,"shape_dirty");
+        let shape_dirty          = ShapeDirty::new(sub_logger,Box::new(on_mut.clone()));
+        let sub_logger           = Logger::sub(&logger,"symbols_dirty");
+        let dirty_flag           = SymbolRegistryDirty::new(sub_logger,Box::new(on_mut));
+        let on_change            = enclose!((dirty_flag) move || dirty_flag.set());
+        let var_logger           = Logger::sub(&logger,"global_variables");
+        let variables            = UniformScope::new(var_logger,&context);
+        let symbols              = SymbolRegistry::mk(&variables,&stats,&context,&logger,on_change);
+        let screen_shape         = dom.shape();
+        let width                = screen_shape.width;
+        let height               = screen_shape.height;
+        let symbols_dirty        = dirty_flag;
+        let views                = Views::mk(&logger,width,height);
+        let stats                = stats.clone();
+        let shapes               = ShapeRegistry::default();
+        let uniforms             = Uniforms::new(&variables);
+        let dirty                = Dirty {symbols:symbols_dirty,shape:shape_dirty};
+        let renderer             = Renderer::new(&logger,&dom,&context,&variables);
+        let style_sheet          = style::Sheet::new();
+        let fonts                = font::SharedRegistry::new();
+        let frp                  = Frp::new(&dom.root.shape);
+        let mouse_logger         = Logger::sub(&logger,"mouse");
+        let mouse                = Mouse::new(&frp,&variables,mouse_logger);
+        let disable_context_menu = Rc::new(web::ignore_context_menu(&dom.root).unwrap());
+        let keyboard             = Keyboard::new();
+        let network              = &frp.network;
+        let extensions           = Extensions::default();
+        let bg_color_var         = style_sheet.var("application . background . color");
+        let bg_color_change      = bg_color_var.on_change(f!([dom](change){
             change.color().for_each(|color| {
                 let color = color::Rgba::from(color);
                 let color = format!("rgba({},{},{},{})",255.0*color.red,255.0*color.green,255.0*color.blue,255.0*color.alpha);
@@ -914,7 +931,7 @@ impl SceneData {
         uniforms.pixel_ratio.set(dom.shape().pixel_ratio);
         Self {renderer,display_object,dom,context,symbols,views,dirty,logger,variables,stats
              ,uniforms,mouse,keyboard,shapes,style_sheet,bg_color_var,bg_color_change,fonts,frp
-             ,extensions}
+             ,extensions,disable_context_menu}
     }
 
     pub fn shape(&self) -> &frp::Sampler<Shape> {

--- a/src/rust/ensogl/lib/core/src/display/scene.rs
+++ b/src/rust/ensogl/lib/core/src/display/scene.rs
@@ -785,7 +785,7 @@ impl Frp {
             event_is_passed_to_js      <+ pass_processed_event_to_js.constant(true);
             processed_event            <- any(...);
 
-            event_is_being_chainged <- processed_event_source.map3(&processed_event,&event_is_passed_to_js,
+            event_is_being_changed <- processed_event_source.map3(&processed_event,&event_is_passed_to_js,
                 |new:&Option<web_sys::Event>, current:&Option<web_sys::Event>, is_passed| {
                     if let Some(e) = current {
                         if !is_passed {
@@ -795,8 +795,8 @@ impl Frp {
                     new.clone()
                 }
             );
-            event_is_passed_to_js <+ event_is_being_chainged.constant(false);
-            processed_event       <+ event_is_being_chainged;
+            event_is_passed_to_js <+ event_is_being_changed.constant(false);
+            processed_event       <+ event_is_being_changed;
         }
         let shape           = shape.clone_ref();
         let camera_changed  = camera_changed_source.clone_ref().into();

--- a/src/rust/ensogl/lib/core/src/display/shape.rs
+++ b/src/rust/ensogl/lib/core/src/display/shape.rs
@@ -5,3 +5,5 @@ pub mod primitive;
 pub mod text;
 
 pub use primitive::*;
+//TODO[ao] we have two Shape traits and two ShapeOps traits. Which should take precedence?
+pub use primitive::def::class::ShapeOps;

--- a/src/rust/ensogl/lib/core/src/display/shape.rs
+++ b/src/rust/ensogl/lib/core/src/display/shape.rs
@@ -5,5 +5,5 @@ pub mod primitive;
 pub mod text;
 
 pub use primitive::*;
-//TODO[ao] we have two Shape traits and two ShapeOps traits. Which should take precedence?
+// We have two Shape and two ShapeOps traits. This one takes precedence.
 pub use primitive::def::class::ShapeOps;

--- a/src/rust/ensogl/lib/core/src/display/shape/primitive/system.rs
+++ b/src/rust/ensogl/lib/core/src/display/shape/primitive/system.rs
@@ -150,6 +150,18 @@ pub trait Shape : display::Object + CloneRef + Debug + Sized {
 /// Accessor for the `Shape::System` associated type.
 pub type ShapeSystemOf<T> = <T as Shape>::System;
 
+/// Additional operations implemented for all structures implementing `Shape`.
+pub trait ShapeOps {
+    /// Check if given mouse-event-target means this shape.
+    fn is_this_target(&self,target:display::scene::Target) -> bool;
+}
+
+impl<T:Shape> ShapeOps for T {
+    fn is_this_target(&self, target:display::scene::Target) -> bool {
+        self.sprites().iter().any(|s| s.is_this_target(target))
+    }
+}
+
 
 
 // ==================

--- a/src/rust/ensogl/lib/core/src/display/symbol/gpu/geometry/compound/sprite.rs
+++ b/src/rust/ensogl/lib/core/src/display/symbol/gpu/geometry/compound/sprite.rs
@@ -198,6 +198,15 @@ impl Sprite {
     pub fn symbol_id(&self) -> i32 {
         self.symbol.id
     }
+
+    /// Check if given mouse-event-target means this visualization.
+    pub fn is_this_target(&self, target:display::scene::Target) -> bool {
+        match target {
+            display::scene::Target::Background                      => false,
+            display::scene::Target::Symbol {symbol_id, instance_id} =>
+                self.symbol_id() == symbol_id as i32 && *self.instance_id == instance_id as usize,
+        }
+    }
 }
 
 impl display::Object for Sprite {

--- a/src/rust/ide/view/graph-editor/src/component/visualization/container.rs
+++ b/src/rust/ide/view/graph-editor/src/component/visualization/container.rs
@@ -432,11 +432,8 @@ impl ContainerModel {
 
     /// Check if given mouse-event-target means this visualization.
     fn is_this_target(&self, target:scene::Target) -> bool {
-        use ensogl::display::shape::primitive::system::Shape;
-        self.view.overlay.shape.sprites().iter().map(|s| scene::Target::Symbol {
-            symbol_id   : s.symbol.id as u32,
-            instance_id : *s.instance_id as u32,
-        }).any(|t| t == target)
+        use ensogl::display::shape::primitive::system::ShapeOps;
+        self.view.overlay.shape.is_this_target(target)
     }
 }
 

--- a/src/rust/ide/view/graph-editor/src/component/visualization/container.rs
+++ b/src/rust/ide/view/graph-editor/src/component/visualization/container.rs
@@ -466,21 +466,6 @@ impl Container {
         Self {model,frp,network} . init(scene)
     }
 
-    /// Sets pointer-events `value` of all `HtmlElement`s of the `visualization` class.
-    pub fn set_all_visualizations_pointer_events(value:impl Str) {
-        use wasm_bindgen::JsCast;
-        let value    = value.into();
-        let elements = ensogl::system::web::get_elements_by_class_name("visualization");
-        let logger   = Logger::new("Visualizations");
-        if let Ok(elements) = elements {
-            for element in elements {
-                if let Ok(html_element) = element.dyn_into::<web_sys::HtmlElement>() {
-                    html_element.set_style_or_warn("pointer-events",&value,&logger)
-                }
-            }
-        }
-    }
-
     fn init(self,scene:&Scene) -> Self {
         let inputs     = &self.frp;
         let network    = &self.network;
@@ -498,9 +483,7 @@ impl Container {
             eval_ inputs.enable_fullscreen (model.enable_fullscreen());
             eval_ inputs.enable_fullscreen (fullscreen.set_target_value(1.0));
             eval  inputs.set_size          ((s) size.set_target_value(*s));
-            eval_ model.view.overlay.events.mouse_down([] {
-                Container::set_all_visualizations_pointer_events("auto");
-            });
+            eval_ model.view.overlay.events.mouse_down(scene.frp.pass_processed_event_to_js.emit(()));
 
             _eval <- fullscreen.value.all_with3(&size.value,&inputs.scene_shape,
                 f!([model] (weight,viz_size,scene_size) {

--- a/src/rust/ide/view/graph-editor/src/component/visualization/foreign/java_script/instance.rs
+++ b/src/rust/ide/view/graph-editor/src/component/visualization/foreign/java_script/instance.rs
@@ -236,8 +236,7 @@ impl Instance {
             mouse_position <- scene.mouse.frp.position.constant(());
             caught_mouse   <- any(mouse_up,mouse_down,mouse_wheel,mouse_position);
             should_process <- caught_mouse.gate(&frp.is_active);
-            trace should_process;
-            eval_ should_process ([scene] scene.frp.pass_processed_event_to_js.emit(()));
+            eval_ should_process (scene.frp.pass_processed_event_to_js.emit(()));
         }
         self
     }

--- a/src/rust/ide/view/graph-editor/src/component/visualization/foreign/java_script/instance.rs
+++ b/src/rust/ide/view/graph-editor/src/component/visualization/foreign/java_script/instance.rs
@@ -228,15 +228,15 @@ impl Instance {
                 if let Err(e) = model.receive_data(data) {
                     frp.data_receive_error.emit(Some(e));
                 }
-             });
+            });
 
-            mouse_up       <- scene.mouse.frp.up.constant(());
-            mouse_down     <- scene.mouse.frp.down.constant(());
-            mouse_wheel    <- scene.mouse.frp.wheel.constant(());
-            mouse_position <- scene.mouse.frp.position.constant(());
-            caught_mouse   <- any(mouse_up,mouse_down,mouse_wheel,mouse_position);
-            should_process <- caught_mouse.gate(&frp.is_active);
-            eval_ should_process (scene.frp.pass_processed_event_to_js.emit(()));
+            let mouse_up       =  scene.mouse.frp.up.clone_ref();
+            let mouse_down     =  scene.mouse.frp.down.clone_ref();
+            let mouse_wheel    =  scene.mouse.frp.wheel.clone_ref();
+            let mouse_position =  scene.mouse.frp.position.clone_ref();
+            caught_mouse       <- any_(mouse_up,mouse_down,mouse_wheel,mouse_position);
+            should_process     <- caught_mouse.gate(&frp.is_active);
+            eval_ should_process (scene.frp.pass_current_js_event_to_dom.emit(()));
         }
         self
     }

--- a/src/rust/ide/view/graph-editor/src/component/visualization/foreign/java_script/instance.rs
+++ b/src/rust/ide/view/graph-editor/src/component/visualization/foreign/java_script/instance.rs
@@ -22,7 +22,6 @@ use ensogl::display::Scene;
 use ensogl::display;
 use ensogl::system::web;
 use ensogl::system::web::JsValue;
-use ensogl::system::web::StyleSetter;
 use js_sys;
 use std::fmt::Formatter;
 
@@ -99,7 +98,6 @@ impl InstanceModel {
     fn create_root() -> result::Result<DomSymbol, Error> {
         let div       = web::create_div();
         let root_node = DomSymbol::new(&div);
-        root_node.dom().set_style_or_warn("pointer-events", "none", &Logger::new("CreateRoot"));
         root_node.dom().set_attribute("class","visualization")
             .map_err(|js_error|Error::ConstructorError{js_error})?;
         Ok(root_node)

--- a/src/rust/ide/view/graph-editor/src/component/visualization/instance.rs
+++ b/src/rust/ide/view/graph-editor/src/component/visualization/instance.rs
@@ -40,8 +40,8 @@ pub struct Frp {
     pub data_receive_error    : frp::Source<Option<DataError>>,
     pub change                : frp::Source<EnsoCode>,
     pub preprocess_change     : frp::Source<EnsoCode>,
-    pub activate              : frp::Source<()>,
-    pub deactivate            : frp::Source<()>,
+    pub activate              : frp::Source,
+    pub deactivate            : frp::Source,
 }
 
 impl FrpInputs {

--- a/src/rust/ide/view/graph-editor/src/component/visualization/instance.rs
+++ b/src/rust/ide/view/graph-editor/src/component/visualization/instance.rs
@@ -35,10 +35,13 @@ pub struct Frp {
     pub on_change             : frp::Stream<EnsoCode>,
     pub on_preprocess_change  : frp::Stream<EnsoCode>,
     pub on_data_receive_error : frp::Stream<Option<DataError>>,
+    pub is_active             : frp::Stream<bool>,
 
     pub data_receive_error    : frp::Source<Option<DataError>>,
     pub change                : frp::Source<EnsoCode>,
     pub preprocess_change     : frp::Source<EnsoCode>,
+    pub activate              : frp::Source<()>,
+    pub deactivate            : frp::Source<()>,
 }
 
 impl FrpInputs {
@@ -59,13 +62,16 @@ impl Frp {
             def change             = source();
             def preprocess_change  = source();
             def data_receive_error = source();
+            def activate           = source();
+            def deactivate         = source();
+            is_active              <- bool(&deactivate,&activate);
         };
         let on_change             = change.clone_ref().into();
         let on_preprocess_change  = preprocess_change.clone_ref().into();
         let on_data_receive_error = data_receive_error.clone_ref().into();
         let inputs                = FrpInputs::new(&network);
-        Self {on_change,on_preprocess_change,on_data_receive_error,change,preprocess_change
-             ,inputs,data_receive_error}
+        Self {on_change,on_preprocess_change,on_data_receive_error,is_active,change,
+            preprocess_change,inputs,data_receive_error,activate,deactivate}
     }
 }
 

--- a/src/rust/ide/view/graph-editor/src/component/visualization/instance.rs
+++ b/src/rust/ide/view/graph-editor/src/component/visualization/instance.rs
@@ -65,6 +65,7 @@ impl Frp {
             def activate           = source();
             def deactivate         = source();
             is_active              <- bool(&deactivate,&activate);
+            trace is_active;
         };
         let on_change             = change.clone_ref().into();
         let on_preprocess_change  = preprocess_change.clone_ref().into();

--- a/src/rust/ide/view/graph-editor/src/lib.rs
+++ b/src/rust/ide/view/graph-editor/src/lib.rs
@@ -36,7 +36,6 @@ pub mod data;
 use crate::component::node;
 use crate::component::visualization;
 use crate::component::visualization::MockDataGenerator3D;
-use crate::component::visualization::Container;
 
 use enso_frp as frp;
 use ensogl::application::Application;
@@ -1713,18 +1712,6 @@ fn new_graph_editor(app:&Application) -> GraphEditor {
     frp::extend! { network
         eval_ inputs.debug_push_breadcrumb(model.breadcrumbs.frp.debug.push_breadcrumb.emit(None));
         eval_ inputs.debug_pop_breadcrumb (model.breadcrumbs.frp.debug.pop_breadcrumb.emit(()));
-    }
-
-
-
-    // ============================
-    // === Visualization Events ===
-    // ============================
-
-    frp::extend! { network
-        eval_ touch.background.selected([] {
-            Container::set_all_visualizations_pointer_events("none")
-        });
     }
 
 


### PR DESCRIPTION
### Pull Request Description
This is a partial work on visualization pointer events refactoring. It added "active" state of visualizations and pass mouse events to the vis if it is active. The keyboard events could be managed the same way once shrotcut provider will be fixed (https://github.com/enso-org/ide/issues/713).

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/main/docs/style-guide/rust.md).
- [x] All code has been tested where possible.
- [x] All code has been profiled where possible.

