### PR TITLE
Handling missing main method on startup and `here.main` syntax

### DIFF
--- a/src/rust/ide/src/controller/graph.rs
+++ b/src/rust/ide/src/controller/graph.rs
@@ -456,8 +456,7 @@ impl Handle {
         let root_id     = project.content_root_id();
         let module_path = model::module::Path::from_method(root_id,&method)?;
         let module      = project.module(module_path).await?;
-        let module_ast  = module.ast();
-        let definition  = double_representation::module::lookup_method(&module_ast,&method)?;
+        let definition  = module.lookup_method(&method)?;
         Self::new(parent,module,project.suggestion_db(),project.parser(),definition)
     }
 

--- a/src/rust/ide/src/double_representation/definition.rs
+++ b/src/rust/ide/src/double_representation/definition.rs
@@ -571,10 +571,10 @@ mod tests {
     fn generating_definition_to_add() {
         let parser     = Parser::new_or_panic();
         let mut to_add = ToAdd {
-            name : DefinitionName::new_method("Main","add"),
+            name                     : DefinitionName::new_method("Main","add"),
             explicit_parameter_names : vec!["arg1".into(), "arg2".into()],
-            body_head : Ast::infix_var("ret","=","arg2"),
-            body_tail : default(),
+            body_head                : Ast::infix_var("ret","=","arg2"),
+            body_tail                : default(),
         };
 
         // First, if we generate definition with single line and it is assignment,

--- a/src/rust/ide/src/double_representation/identifier.rs
+++ b/src/rust/ide/src/double_representation/identifier.rs
@@ -217,6 +217,11 @@ impl ReferentName {
     pub fn new(name:impl Str) -> Result<ReferentName, NotReferentName> {
         Self::validate(name.as_ref()).map(|_| ReferentName(name.into()))
     }
+
+    /// Get a normalized version of this identifier.
+    pub fn normalized(&self) -> NormalizedName {
+        NormalizedName::new(self)
+    }
 }
 
 

--- a/src/rust/ide/src/double_representation/module.rs
+++ b/src/rust/ide/src/double_representation/module.rs
@@ -734,7 +734,7 @@ mod tests {
         info.expect_code("import Bar.Gar");
     }
 
-    #[test]
+    #[wasm_bindgen_test]
     fn implicit_method_resolution() {
         let parser         = parser::Parser::new_or_panic();
         let module_name    = ReferentName::new("Main").unwrap();

--- a/src/rust/ide/src/double_representation/module.rs
+++ b/src/rust/ide/src/double_representation/module.rs
@@ -2,11 +2,12 @@
 
 use crate::prelude::*;
 
+use crate::constants::keywords::HERE;
 use crate::double_representation::definition;
-use crate::double_representation::definition::DefinitionName;
 use crate::double_representation::definition::DefinitionProvider;
 use crate::double_representation::identifier;
 use crate::double_representation::identifier::Identifier;
+use crate::double_representation::identifier::NormalizedName;
 use crate::double_representation::identifier::LocatedName;
 use crate::double_representation::identifier::ReferentName;
 
@@ -587,7 +588,7 @@ pub fn locate
     // Not exactly regular - we need special case for the first crumb as it is not a definition nor
     // a children. After this we can go just from one definition to another.
     let first_crumb = crumbs_iter.next().ok_or(EmptyDefinitionId)?;
-    let mut child = ast.def_iter().find_by_name(&first_crumb)?;
+    let mut child   = ast.def_iter().find_by_name(&first_crumb)?;
     for crumb in crumbs_iter {
         child = definition::resolve_single_name(child,crumb)?;
     }
@@ -598,18 +599,27 @@ pub fn locate
 ///
 /// The module is assumed to be in the file identified by the `method.file` (for the purpose of
 /// desugaring implicit extensions methods for modules).
+///
+/// The `name` parameter is the name of the module that contains `ast`. It affects how the `here`
+/// keyword is resolved.
 pub fn lookup_method
-(ast:&known::Module, method:&language_server::MethodPointer) -> FallibleResult<definition::Id> {
-    let module_name                    = QualifiedName::try_from(method)?;
-    let explicitly_extends_looked_type = method.defined_on_type == module_name.name().as_ref();
-
+(name:&ReferentName, ast:&known::Module, method:&language_server::MethodPointer)
+-> FallibleResult<definition::Id> {
+    let normalized_typename        = NormalizedName::new(&method.defined_on_type);
+    let accept_here_methods        = name.normalized() == normalized_typename;
+    let module_name                = QualifiedName::try_from(method)?;
+    let implicit_extension_allowed = method.defined_on_type == module_name.name().as_ref();
     for child in ast.def_iter() {
-        let child_name : &DefinitionName = &child.name.item;
+        let child_name   = &child.name.item;
         let name_matches = child_name.name.item == method.name;
         let type_matches = match child_name.extended_target.as_slice() {
-            []         => explicitly_extends_looked_type,
-            [typename] => typename.item == method.defined_on_type,
-            _          => child_name.explicitly_extends_type(&method.defined_on_type),
+            []         => implicit_extension_allowed,
+            [typename] => {
+                let explicit_type_matching  = typename.item == method.defined_on_type;
+                let here_extension_matching = typename.item == HERE && accept_here_methods;
+                explicit_type_matching || here_extension_matching
+            }
+            _ => child_name.explicitly_extends_type(&method.defined_on_type),
         };
         if name_matches && type_matches {
             return Ok(definition::Id::new_single_crumb(child_name.clone()))
@@ -715,18 +725,13 @@ mod tests {
         info.expect_code("import Bar.Gar");
     }
 
-    #[wasm_bindgen_test]
+    #[test]
     fn implicit_method_resolution() {
-        let parser = parser::Parser::new_or_panic();
-        let foo_method = MethodPointer {
-            defined_on_type : "Main".into(),
-            module          : "ProjectName.Main".into(),
-            name            : "foo".into(),
-        };
-
-        let expect_find = |code,expected:definition::Id| {
+        let parser         = parser::Parser::new_or_panic();
+        let module_name    = ReferentName::new("Main").unwrap();
+        let expect_find    = |method:&MethodPointer, code,expected:&definition::Id| {
             let module = parser.parse_module(code,default()).unwrap();
-            let result = lookup_method(&module,&foo_method);
+            let result = lookup_method(&module_name,&module,method);
             assert_eq!(result.unwrap().to_string(),expected.to_string());
 
             // TODO [mwu]
@@ -736,21 +741,50 @@ mod tests {
             //  ones. Definition ID should not require any location info.
         };
 
-        let expect_not_found = |code| {
+        let expect_not_found = |method:&MethodPointer, code| {
             let module = parser.parse_module(code,default()).unwrap();
-            lookup_method(&module,&foo_method).expect_err("expected method not found");
+            lookup_method(&module_name,&module,method).expect_err("expected method not found");
+        };
+
+
+        // === Lookup the Main (local module type) extension method ===
+
+        let ptr = MethodPointer {
+            defined_on_type : "Main".into(),
+            module          : "ProjectName.Main".into(),
+            name            : "foo".into(),
         };
 
         // Implicit module extension method.
         let id = definition::Id::new_plain_name("foo");
-        expect_find("foo a b = a + b", id);
-        // Explicit module extension method
+        expect_find(&ptr,"foo a b = a + b",&id);
+        // Explicit module extension method.
         let id = definition::Id::new_single_crumb(DefinitionName::new_method("Main","foo"));
-        expect_find("Main.foo a b = a + b", id);
+        expect_find(&ptr,"Main.foo a b = a + b",&id);
+        // Explicit extensions using "here" keyword.
+        let id = definition::Id::new_single_crumb(DefinitionName::new_method("here","foo"));
+        expect_find(&ptr,"here.foo a b = a + b",&id);
+        // Matching name but extending wrong type.
+        expect_not_found(&ptr,"Int.foo a b = a + b");
+        // Mismatched name.
+        expect_not_found(&ptr,"bar a b = a + b");
 
-        expect_not_found("bar a b = a + b");
+
+        // === Lookup the Int (non-local type) extension method ===
+
+        let ptr = MethodPointer {
+            defined_on_type : "Int".into(),
+            module          : "ProjectName.Main".into(),
+            name            : "foo".into(),
+        };
+
+        expect_not_found(&ptr,"foo a b = a + b");
+        let id = definition::Id::new_single_crumb(DefinitionName::new_method("Int","foo"));
+        expect_find(&ptr,"Int.foo a b = a + b",&id);
+        expect_not_found(&ptr,"Text.foo a b = a + b");
+        expect_not_found(&ptr,"here.foo a b = a + b");
+        expect_not_found(&ptr,"bar a b = a + b");
     }
-
 
     #[wasm_bindgen_test]
     fn test_definition_location() {

--- a/src/rust/ide/src/double_representation/module.rs
+++ b/src/rust/ide/src/double_representation/module.rs
@@ -609,13 +609,13 @@ pub fn locate
 /// The module is assumed to be in the file identified by the `method.file` (for the purpose of
 /// desugaring implicit extensions methods for modules).
 ///
-/// The `name` parameter is the name of the module that contains `ast`. It affects how the `here`
-/// keyword is resolved.
+/// The `module_name` parameter is the name of the module that contains `ast`. It affects how the
+/// `here` keyword is resolved.
 pub fn lookup_method
-(name:&ReferentName, ast:&known::Module, method:&language_server::MethodPointer)
+(module_name:&ReferentName, ast:&known::Module, method:&language_server::MethodPointer)
 -> FallibleResult<definition::Id> {
     let normalized_typename        = NormalizedName::new(&method.defined_on_type);
-    let accept_here_methods        = name.normalized() == normalized_typename;
+    let accept_here_methods        = module_name.normalized() == normalized_typename;
     let module_name                = QualifiedName::try_from(method)?;
     let implicit_extension_allowed = method.defined_on_type == module_name.name().as_ref();
     for child in ast.def_iter() {

--- a/src/rust/ide/src/double_representation/module.rs
+++ b/src/rust/ide/src/double_representation/module.rs
@@ -416,13 +416,13 @@ impl Info {
         index_to_place_at
     }
 
-    /// Add a new method definition to the module.
-    pub fn add_method
-    (&mut self, method:definition::ToAdd, location:Placement, parser:&parser::Parser)
-    -> FallibleResult<()> {
-        let no_indent      = 0;
-        let definition_ast = method.ast(no_indent,parser)?;
-
+    /// Place the line with given AST in the module's body.
+    ///
+    /// Unlike `add_line` (which is more low-level) will introduce empty lines around introduced
+    /// line and describes the added line location in relation to other definitions.
+    ///
+    /// Typically used to place lines with definitions in the module.
+    pub fn add_ast(&mut self, ast:Ast, location:Placement) -> FallibleResult<()> {
         #[derive(Clone,Copy,Debug,Eq,PartialEq)]
         enum BlankLinePlacement {Before,After,None};
         let blank_line = match location {
@@ -448,12 +448,21 @@ impl Info {
         if blank_line == BlankLinePlacement::Before {
             add_line(None);
         }
-        add_line(Some(definition_ast));
+        add_line(Some(ast));
         if blank_line == BlankLinePlacement::After {
             add_line(None);
         }
 
         Ok(())
+    }
+
+    /// Add a new method definition to the module.
+    pub fn add_method
+    (&mut self, method:definition::ToAdd, location:Placement, parser:&parser::Parser)
+    -> FallibleResult<()> {
+        let no_indent      = 0;
+        let definition_ast = method.ast(no_indent,parser)?;
+        self.add_ast(definition_ast,location)
     }
 
     #[cfg(test)]

--- a/src/rust/ide/src/model/module.rs
+++ b/src/rust/ide/src/model/module.rs
@@ -454,6 +454,17 @@ pub trait API:Debug {
     fn id(&self) -> Id {
         self.path().id()
     }
+
+    /// Get a definition ID that points to a method matching given pointer.
+    ///
+    /// The module is assumed to be in the file identified by the `method.file` (for the purpose of
+    /// desugaring implicit extensions methods for modules).
+    fn lookup_method
+    (&self, method:&MethodPointer) -> FallibleResult<double_representation::definition::Id> {
+        let name = self.path().module_name();
+        let ast  = self.ast();
+        double_representation::module::lookup_method(&name,&ast,method)
+    }
 }
 
 /// The general, shared Module Model handle.

--- a/src/rust/ide/src/model/module.rs
+++ b/src/rust/ide/src/model/module.rs
@@ -465,6 +465,11 @@ pub trait API:Debug {
         let ast  = self.ast();
         double_representation::module::lookup_method(&name,&ast,method)
     }
+
+    /// Get the double representation information about module.
+    fn info(&self) -> double_representation::module::Info {
+        double_representation::module::Info::from(self.ast())
+    }
 }
 
 /// The general, shared Module Model handle.

--- a/src/rust/ide/src/test.rs
+++ b/src/rust/ide/src/test.rs
@@ -179,8 +179,7 @@ pub mod mock {
          -> crate::controller::Graph {
             let parser      = self.parser.clone_ref();
             let method      = self.method_pointer();
-            let module_ast  = module.ast();
-            let definition  = module::lookup_method(&module_ast,&method).unwrap();
+            let definition  = module.lookup_method(&method).unwrap();
             crate::controller::Graph::new(logger,module,db,parser,definition).unwrap()
         }
 

--- a/src/rust/ide/src/test.rs
+++ b/src/rust/ide/src/test.rs
@@ -132,6 +132,12 @@ pub mod mock {
             self.code = format!("{} = {}",method.name,code.as_ref())
         }
 
+        pub fn set_code(&mut self, code:impl Into<String>) {
+            self.code     = code.into();
+            self.id_map   = default();
+            self.metadata = default();
+        }
+
         pub fn new() -> Self {
             use crate::test::mock::data::*;
             let mut suggestions = HashMap::new();

--- a/src/rust/ide/src/view/project.rs
+++ b/src/rust/ide/src/view/project.rs
@@ -52,7 +52,7 @@ pub fn default_main_method_code() -> String {
 
 /// The default content of the newly created initial main module file.
 pub fn default_main_module_code() -> String {
-    format!("{}",default_main_method_code())
+    default_main_method_code()
 }
 
 /// Method pointer that described the main method, i.e. the method that project view wants to open

--- a/src/rust/ide/src/view/project.rs
+++ b/src/rust/ide/src/view/project.rs
@@ -163,10 +163,10 @@ impl ProjectView {
         let resize_callback          = None;
         let mut fonts                = font::Registry::new();
         let visualization_controller = project.visualization().clone();
-        let layout = ViewLayout::new(&logger, &mut keyboard_actions, &application, text_controller,
-            graph_controller, visualization_controller, project.clone_ref(), &mut fonts).await?;
-        let data = ProjectViewData {application,layout,resize_callback,
-            model: project,keyboard,
+        let layout = ViewLayout::new(&logger,&mut keyboard_actions,&application,text_controller,
+            graph_controller,visualization_controller,project.clone_ref(),&mut fonts).await?;
+        let model = project;
+        let data = ProjectViewData {model,application,layout,resize_callback,keyboard,
             keyboard_bindings,keyboard_actions,navigator};
         Ok(Self::new_from_data(data).init())
     }
@@ -233,5 +233,4 @@ mod tests {
         expect_intact("here.main = 5");
         expect_intact(&format!("{}.main = 5",module_name));
     }
-
 }

--- a/src/rust/ide/src/view/project.rs
+++ b/src/rust/ide/src/view/project.rs
@@ -45,18 +45,14 @@ pub const INITIAL_MODULE_NAME:&str = "Main";
 /// This is the definition whose graph will be opened on IDE start.
 pub const MAIN_DEFINITION_NAME:&str = "main";
 
-/// Code of the import declaration required by the default implementation of the main method
-/// (see [default_main_module_code] function).
-pub const DEFAULT_MAIN_IMPORT:&str = "from Base import all";
-
 /// The code with definition of the default `main` method.
 pub fn default_main_method_code() -> String {
-    format!(r#"{} = IO.println "Hello, World!""#, MAIN_DEFINITION_NAME)
+    format!(r#"{} = "Hello, World!""#, MAIN_DEFINITION_NAME)
 }
 
 /// The default content of the newly created initial main module file.
 pub fn default_main_module_code() -> String {
-    format!("{}\n\n{}",DEFAULT_MAIN_IMPORT,default_main_method_code())
+    format!("{}",default_main_method_code())
 }
 
 /// Method pointer that described the main method, i.e. the method that project view wants to open
@@ -129,8 +125,7 @@ pub fn add_main_if_missing
 
 impl ProjectView {
     /// Create a new ProjectView.
-    pub async fn new(logger:impl AnyLogger, project:model::Project)
-                     -> FallibleResult<Self> {
+    pub async fn new(logger:impl AnyLogger, project:model::Project) -> FallibleResult<Self> {
         let logger      = Logger::sub(logger,"ProjectView");
         let module_path = initial_module_path(&project)?;
         let file_path   = module_path.file_path().clone();

--- a/src/rust/ide/src/view/project.rs
+++ b/src/rust/ide/src/view/project.rs
@@ -15,10 +15,12 @@ use ensogl::display::shape::text::glyph::font;
 use ensogl::system::web;
 use enso_frp::io::keyboard::Keyboard;
 use enso_frp::io::keyboard;
+use enso_protocol::language_server::MethodPointer;
 use enso_shapely::shared;
 use ensogl_theme;
 use ide_view::graph_editor;
 use nalgebra::Vector2;
+use parser::Parser;
 
 
 
@@ -43,8 +45,25 @@ pub const INITIAL_MODULE_NAME:&str = "Main";
 /// This is the definition whose graph will be opened on IDE start.
 pub const MAIN_DEFINITION_NAME:&str = "main";
 
-/// The default content of the newly created initial module file.
-pub const DEFAULT_MAIN_CONTENT:&str = r#"main = IO.println "Hello, World!""#;
+/// Code of the import declaration required by the default implementation of the main method
+/// (see [default_main_module_code] function).
+pub const DEFAULT_MAIN_IMPORT:&str = "from Base import all";
+
+/// The code with definition of the default `main` method.
+pub fn default_main_method_code() -> String {
+    format!(r#"{} = IO.println "Hello, World!""#, MAIN_DEFINITION_NAME)
+}
+
+/// The default content of the newly created initial main module file.
+pub fn default_main_module_code() -> String {
+    format!("{}\n\n{}",DEFAULT_MAIN_IMPORT,default_main_method_code())
+}
+
+/// Method pointer that described the main method, i.e. the method that project view wants to open
+/// and which presence is currently required.
+pub fn main_method_ptr(project_name:impl Str, module_path:&model::module::Path) -> MethodPointer {
+    module_path.method_pointer(project_name,MAIN_DEFINITION_NAME)
+}
 
 
 
@@ -91,20 +110,44 @@ pub async fn recreate_if_missing(project:&model::Project, path:&FilePath, defaul
     Ok(())
 }
 
+/// Add main method definition to the given module, if the method is not already defined.
+///
+/// The lookup will be done using the given `main_ptr` value.
+pub fn add_main_if_missing
+(module:&model::Module, main_ptr:&MethodPointer, parser:&Parser) -> FallibleResult<()> {
+    if module.lookup_method(main_ptr).is_err() {
+        let mut info  = module.info();
+        let main_code = default_main_method_code();
+        let main_ast  = parser.parse_line(main_code)?;
+        info.add_ast(main_ast,double_representation::module::Placement::End)?;
+        module.update_ast(info.ast);
+
+        // TODO [mwu] Add imports required by the default main definition (when needed).
+    }
+    Ok(())
+}
+
 impl ProjectView {
     /// Create a new ProjectView.
-    pub async fn new(logger:impl AnyLogger, model:model::Project)
-    -> FallibleResult<Self> {
+    pub async fn new(logger:impl AnyLogger, project:model::Project)
+                     -> FallibleResult<Self> {
         let logger      = Logger::sub(logger,"ProjectView");
-        let module_path = initial_module_path(&model)?;
+        let module_path = initial_module_path(&project)?;
         let file_path   = module_path.file_path().clone();
         // TODO [mwu] This solution to recreate missing main file should be considered provisional
         //   until proper decision is made. See: https://github.com/enso-org/enso/issues/1050
-        recreate_if_missing(&model,&file_path,DEFAULT_MAIN_CONTENT.into()).await?;
-        let text_controller   = controller::Text::new(&logger,&model,file_path).await?;
-        let method            = module_path.method_pointer(model.name(),MAIN_DEFINITION_NAME);
-        let graph_controller  = controller::ExecutedGraph::new(&logger,model.clone_ref(),method);
+        recreate_if_missing(&project, &file_path, default_main_method_code()).await?;
+
+        let method = main_method_ptr(project.name(),&module_path);
+        let module = project.module(module_path).await?;
+        add_main_if_missing(&module,&method,&project.parser())?;
+
+        // Here, we should be relatively certain (except race conditions in case of multiple clients
+        // that we currently do not support) that main module exists and contains main method.
+        // Thus, we should be able to successfully create a graph controller for it.
+        let graph_controller  = controller::ExecutedGraph::new(&logger,project.clone_ref(),method);
         let graph_controller  = graph_controller.await?;
+        let text_controller   = controller::Text::new(&logger, &project, file_path).await?;
         let application       = Application::new(&web::get_html_element_by_id("root").unwrap());
         let scene             = application.display.scene();
         let camera            = scene.camera();
@@ -119,10 +162,11 @@ impl ProjectView {
         let mut keyboard_actions     = keyboard::Actions::new(&keyboard);
         let resize_callback          = None;
         let mut fonts                = font::Registry::new();
-        let visualization_controller = model.visualization().clone();
-        let layout = ViewLayout::new(&logger,&mut keyboard_actions,&application, text_controller,
-            graph_controller,visualization_controller,model.clone_ref(),&mut fonts).await?;
-        let data = ProjectViewData {application,layout,resize_callback,model,keyboard,
+        let visualization_controller = project.visualization().clone();
+        let layout = ViewLayout::new(&logger, &mut keyboard_actions, &application, text_controller,
+            graph_controller, visualization_controller, project.clone_ref(), &mut fonts).await?;
+        let data = ProjectViewData {application,layout,resize_callback,
+            model: project,keyboard,
             keyboard_bindings,keyboard_actions,navigator};
         Ok(Self::new_from_data(data).init())
     }
@@ -149,4 +193,45 @@ impl ProjectView {
     pub fn forget(self) {
         std::mem::forget(self)
     }
+}
+
+
+
+// =============
+// === Tests ===
+// =============
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::executor::test_utils::TestWithLocalPoolExecutor;
+
+    #[wasm_bindgen_test]
+    fn adding_missing_main() {
+        let _ctx        = TestWithLocalPoolExecutor::set_up();
+        let parser      = parser::Parser::new_or_panic();
+        let mut data    = crate::test::mock::Unified::new();
+        let module_name = data.module_path.module_name();
+        let main_ptr    = main_method_ptr(&data.project_name,&data.module_path);
+
+        // Check that module without main gets it after the call.
+        let empty_module_code = "";
+        data.set_code(empty_module_code);
+        let module = data.module();
+        assert!(module.lookup_method(&main_ptr).is_err());
+        add_main_if_missing(&module,&main_ptr,&parser).unwrap();
+        assert!(module.lookup_method(&main_ptr).is_ok());
+
+        // Now check that modules that have main already defined won't get modified.
+        let mut expect_intact = move |code:&str| {
+            data.set_code(code);
+            let module = data.module();
+            add_main_if_missing(&module,&main_ptr,&parser).unwrap();
+            assert_eq!(code,module.ast().repr());
+        };
+        expect_intact("main = 5");
+        expect_intact("here.main = 5");
+        expect_intact(&format!("{}.main = 5",module_name));
+    }
+
 }


### PR DESCRIPTION
### Pull Request Description
Currently IDE fails to load if `main` method definition in not present or if it uses the `here.main` syntax.
This PR fixes both:
1) method pointer lookup will correctly take into consideration the module name to resolve the `here` symbol (related engine issue: https://github.com/enso-org/enso/issues/1138 ) 
2) if the `main` method cannot be found during the startup, it will be created

Currently I am marking this PR as a draft, because there's one more missing piece — the standard `main` definition stub requires also explicit `Base` import.
To be discussed how to handle this.

### Important Notes
<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/main/docs/style-guide/rust.md).
- [x] All code has been tested where possible.
- [ ] All code has been profiled where possible.

