### PR TITLE
Fix invisible cursor on nodes

### DIFF
--- a/src/rust/ensogl/example/src/text_area.rs
+++ b/src/rust/ensogl/example/src/text_area.rs
@@ -7,6 +7,7 @@ use ensogl_text_msdf_sys::run_once_initialized;
 use wasm_bindgen::prelude::*;
 use ensogl_core::application::Application;
 use ensogl_text::Area;
+use ensogl_core::display::navigation::navigator::Navigator;
 
 
 /// Main example runner.
@@ -26,13 +27,17 @@ pub fn entry_point_text_area() {
 fn init(app:&Application) {
     let area = app.new_view::<Area>();
     area.set_position_x(-100.0);
-    area.set_content("Et Eärello Endorenna utúlien. Sinome maruvan ar Hildinyar tenn' Ambar-metta");
+    area.set_content("Et Eärello Endorenna utúlien.\nSinome maruvan ar Hildinyar tenn' Ambar-metta");
     area.set_active_on();
     area.set_cursor_at_end();
+
+    let scene     = app.display.scene();
+    let navigator = Navigator::new(scene,scene.camera());
 
     app.display.scene().add_child(&area);
     let keep = Some(area);
     app.display.on_frame(move |_frame| {
         let _ = &keep;
     }).forget();
+    std::mem::forget(navigator);
 }

--- a/src/rust/ensogl/lib/text/src/component/area.rs
+++ b/src/rust/ensogl/lib/text/src/component/area.rs
@@ -741,7 +741,13 @@ impl AreaData {
         // initialization of the shape system, not for every area creation. To be improved during
         // refactoring of the architecture some day.
         let shape_system = scene.shapes.shape_system(PhantomData::<selection::Shape>);
+        let symbol       = &shape_system.shape_system.sprite_system.symbol;
         shape_system.shape_system.set_pointer_events(false);
+
+        // FIXME[WD]: This is temporary sorting utility, which places the cursor in front of mouse
+        // pointer and nodes. Should be refactored when proper sorting mechanisms are in place.
+        scene.views.main.remove(symbol);
+        scene.views.label.add(symbol);
 
         Self {scene,logger,frp_endpoints,display_object,glyph_system,buffer,lines,selection_map
             ,camera}.init()


### PR DESCRIPTION
### Pull Request Description
After introducing new Text Editor the selection symbol went to main view, and now it's covered by nodes.

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/main/docs/style-guide/rust.md) style guide.
- [x] All code has been tested where possible.
- [x] All code has been profiled where possible.

