### PR TITLE
Add `filter` and `filter_map` nodes to the FRP library

### DIFF
--- a/src/rust/lib/frp/src/lib.rs
+++ b/src/rust/lib/frp/src/lib.rs
@@ -313,8 +313,8 @@ mod dynamic_mode_tests {
     fn test_filter() {
         let passed_events = Rc::new(Cell::new(0));
         frp::new_network! { network
-            def source     = source::<bool>();
-            def filtered   = source.filter(|&value| value == true);
+            def source   = source::<bool>();
+            def filtered = source.filter(|&value| value == true);
             eval filtered ([passed_events](&value) {
                 assert_eq!(value,true);
                 passed_events.set(passed_events.get() + 1);
@@ -324,6 +324,8 @@ mod dynamic_mode_tests {
         source.emit(false);
         source.emit(true);
         source.emit(true);
+        source.emit(false);
+        source.emit(false);
         assert_eq!(passed_events.get(),2);
     }
 }

--- a/src/rust/lib/frp/src/lib.rs
+++ b/src/rust/lib/frp/src/lib.rs
@@ -308,4 +308,22 @@ mod dynamic_mode_tests {
         some_event.emit(());
         assert_eq!(passed_events.get(), 2);
     }
+
+    #[test]
+    fn test_filter() {
+        let passed_events = Rc::new(Cell::new(0));
+        frp::new_network! { network
+            def source     = source::<bool>();
+            def filtered   = source.filter(|&value| value == true);
+            eval filtered ([passed_events](&value) {
+                assert_eq!(value,true);
+                passed_events.set(passed_events.get() + 1);
+            });
+        };
+
+        source.emit(false);
+        source.emit(true);
+        source.emit(true);
+        assert_eq!(passed_events.get(),2);
+    }
 }

--- a/src/rust/lib/frp/src/lib.rs
+++ b/src/rust/lib/frp/src/lib.rs
@@ -328,4 +328,27 @@ mod dynamic_mode_tests {
         source.emit(false);
         assert_eq!(passed_events.get(),2);
     }
+
+    #[test]
+    fn test_filter_map() {
+        let passed_events = Rc::new(Cell::new(0));
+        frp::new_network! { network
+            def source        = source::<bool>();
+            def filter_mapped = source.filter_map(|&value|
+                match value {
+                    true  => Some(()),
+                    false => None,
+                });
+            eval filter_mapped ([passed_events](_) {
+                passed_events.set(passed_events.get() + 1);
+            });
+        };
+
+        source.emit(false);
+        source.emit(true);
+        source.emit(true);
+        source.emit(false);
+        source.emit(false);
+        assert_eq!(passed_events.get(),2);
+    }
 }

--- a/src/rust/lib/frp/src/lib.rs
+++ b/src/rust/lib/frp/src/lib.rs
@@ -291,64 +291,57 @@ mod dynamic_mode_tests {
     fn test_gate() {
         let passed_events = Rc::new(Cell::new(0));
         frp::new_network! { network
-            def behavior   = source::<bool>();
-            def some_event = source::<()>();
+            behavior   <- source::<bool>();
+            some_event <- source::<()>();
 
-            def gated      = some_event.gate(&behavior);
-            eval gated ([passed_events](()) {
-                passed_events.set(passed_events.get() + 1);
-            });
+            gated      <- some_event.gate(&behavior);
+            eval_ gated (passed_events.set(passed_events.get() + 1));
+
         };
 
-        behavior.emit(false);
-        some_event.emit(());
-        behavior.emit(true);
-        some_event.emit(());
-        behavior.emit(true);
-        some_event.emit(());
-        assert_eq!(passed_events.get(), 2);
+        let input = &[false,true,true];
+        for val in input {
+            behavior.emit(val);
+            some_event.emit(());
+        }
+        let true_count = input.iter().filter(|&&val| val == true).count();
+        assert_eq!(passed_events.get(),true_count);
     }
 
     #[test]
     fn test_filter() {
         let passed_events = Rc::new(Cell::new(0));
         frp::new_network! { network
-            def source   = source::<bool>();
-            def filtered = source.filter(|&value| value == true);
+            source   <- source::<bool>();
+            filtered <- source.filter(|&value| value == true);
             eval filtered ([passed_events](&value) {
                 assert_eq!(value,true);
                 passed_events.set(passed_events.get() + 1);
             });
         };
 
-        source.emit(false);
-        source.emit(true);
-        source.emit(true);
-        source.emit(false);
-        source.emit(false);
-        assert_eq!(passed_events.get(),2);
+        let input = &[false,true,true,false,false];
+        for val in input {
+            source.emit(*val);
+        }
+        let true_count = input.iter().filter(|&&val| val == true).count();
+        assert_eq!(passed_events.get(),true_count);
     }
 
     #[test]
     fn test_filter_map() {
         let passed_events = Rc::new(Cell::new(0));
         frp::new_network! { network
-            def source        = source::<bool>();
-            def filter_mapped = source.filter_map(|&value|
-                match value {
-                    true  => Some(()),
-                    false => None,
-                });
-            eval filter_mapped ([passed_events](_) {
-                passed_events.set(passed_events.get() + 1);
-            });
+            source        <- source::<bool>();
+            filter_mapped <- source.filter_map(|v| v.as_some(()));
+            eval_ filter_mapped (passed_events.set(passed_events.get() + 1));
         };
 
-        source.emit(false);
-        source.emit(true);
-        source.emit(true);
-        source.emit(false);
-        source.emit(false);
-        assert_eq!(passed_events.get(),2);
+        let input = &[false,true,true,false,false];
+        for val in input {
+            source.emit(*val);
+        }
+        let true_count = input.iter().filter(|&&val| val == true).count();
+        assert_eq!(passed_events.get(),true_count);
     }
 }

--- a/src/rust/lib/frp/src/nodes.rs
+++ b/src/rust/lib/frp/src/nodes.rs
@@ -306,9 +306,8 @@ impl Network {
     // === Filter ===
 
     /// Passes exactly those incoming events that satisfy the predicate `p`.
-    pub fn filter<T:EventOutput>
-    (&self, label:Label, src:&T, p:impl'static+Fn(&Output<T>)->bool)
-    -> Stream<Output<T>> {
+    pub fn filter<T,P>(&self, label:Label, src:&T, p:P) -> Stream<Output<T>>
+    where T:EventOutput, P:'static+Fn(&Output<T>)->bool {
         self.register(OwnedFilter::new(label,src,p))
     }
 
@@ -563,10 +562,8 @@ impl DynamicNetwork {
 
 
     // === Filter ===
-
-    pub fn filter<T:EventOutput>
-    (self, label:Label, src:&T, p:impl'static+Fn(&Output<T>)->bool)
-    -> OwnedStream<Output<T>> {
+    pub fn filter<T,P>(&self, label:Label, src:&T, p:P) -> Stream<Output<T>>
+    where T:EventOutput, P:'static+Fn(&Output<T>)->bool {
         OwnedFilter::new(label,src,p).into()
     }
 

--- a/src/rust/lib/frp/src/nodes.rs
+++ b/src/rust/lib/frp/src/nodes.rs
@@ -1676,27 +1676,26 @@ where T1:EventOutput, T2:EventOutput, T3:EventOutput, T4:EventOutput {
 // === Filter ===
 // ==============
 
-pub struct FilterData  <T,P> { _src:T, predicate:P }
+pub struct FilterData  <T,P> { phantom:PhantomData<T>, predicate:P }
 pub type   OwnedFilter <T,P> = stream::Node     <FilterData<T,P>>;
 pub type   Filter      <T,P> = stream::WeakNode <FilterData<T,P>>;
 
 impl<T,P> HasOutput for FilterData<T,P>
-    where T:EventOutput, P:'static+Fn(&Output<T>)->bool {
+where T:EventOutput, P:'static+Fn(&Output<T>)->bool {
     type Output = Output<T>;
 }
 
 impl<T,P> OwnedFilter<T,P>
-    where T:EventOutput, P:'static+Fn(&Output<T>)->bool {
+where T:EventOutput, P:'static+Fn(&Output<T>)->bool {
     /// Constructor.
     pub fn new(label:Label, src:&T, predicate:P) -> Self {
-        let _src       = src.clone_ref();
-        let definition = FilterData {_src,predicate};
+        let definition = FilterData {phantom:PhantomData,predicate};
         Self::construct_and_connect(label,src,definition)
     }
 }
 
 impl<T,P> stream::EventConsumer<Output<T>> for OwnedFilter<T,P>
-    where T:EventOutput, P:'static+Fn(&Output<T>)->bool {
+where T:EventOutput, P:'static+Fn(&Output<T>)->bool {
     fn on_event(&self, value:&Output<T>) {
         if (self.predicate)(value) {
             self.emit_event(value);
@@ -1716,7 +1715,7 @@ impl<T,P> Debug for FilterData<T,P> {
 // === Map ===
 // ===========
 
-pub struct MapData  <T,F> { _src:T, function:F }
+pub struct MapData  <T,F> { phantom:PhantomData<T>, function:F }
 pub type   OwnedMap <T,F> = stream::Node     <MapData<T,F>>;
 pub type   Map      <T,F> = stream::WeakNode <MapData<T,F>>;
 
@@ -1729,8 +1728,7 @@ impl<T,F,Out> OwnedMap<T,F>
 where T:EventOutput, Out:Data, F:'static+Fn(&Output<T>)->Out {
     /// Constructor.
     pub fn new(label:Label, src:&T, function:F) -> Self {
-        let _src       = src.clone_ref();
-        let definition = MapData {_src,function};
+        let definition = MapData {phantom:PhantomData,function};
         Self::construct_and_connect(label,src,definition)
     }
 }


### PR DESCRIPTION
### Pull Request Description
Adds a `filter` node and a `filter_map` node to the FRP library as requested in issue #813.

### Checklist
- [ ] The documentation has been updated if necessary.
- [ ] All code conforms to the [Rust](https://github.com/luna/enso/blob/main/docs/style-guide/rust.md) style guide.
- [ ] All code has been tested where possible.
- [ ] All code has been profiled where possible.

