### PR TITLE
Bump npm node version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v1
         with:
-          node-version: '12.18.4'
+          node-version: '12.19.0'
 
       - name: Build
         run: node ./run dist

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v1
         with:
-          node-version: '12.18.4'
+          node-version: '12.19.0'
 
       - name: Build
         run: node ./run build
@@ -58,7 +58,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v1
         with:
-          node-version: '12.18.4'
+          node-version: '12.19.0'
 
       - name: Building Rust Sources
         run: node ./run lint
@@ -79,7 +79,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v1
         with:
-          node-version: '12.18.4'
+          node-version: '12.19.0'
 
       - name: Run tests
         run: node ./run test --no-wasm
@@ -112,7 +112,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v1
         with:
-          node-version: '12.18.4'
+          node-version: '12.19.0'
 
       - name: Run tests
         run: node ./run test --no-native
@@ -134,7 +134,7 @@ jobs:
   #     - name: Install Node
   #       uses: actions/setup-node@v1
   #       with:
-  #         node-version: '12.18.4'
+  #         node-version: '12.19.0'
   #
   #     - name: Generate test profile
   #       working-directory: src/rust

--- a/build/cmd.js
+++ b/build/cmd.js
@@ -52,11 +52,22 @@ async function check_version (name,required,cfg) {
     version     = version.trim()
     if (cfg.preprocess) { version = cfg.preprocess(version) }
     if (cfg.silent !== true) {
-        console.log(`Checking '${name}' version.`)
+        console.log(`Checking if '${name}' version is '${required}'.`)
     }
     if (version != required) {
         throw `[ERROR] The '${name}' version '${version}' does not match the required one '${required}'.`
     }
 }
 
-module.exports = {section,run,run_read,check_version,with_cwd}
+async function get_npm_info (name) {
+    let info = await run_read('npm',['info',name,'--json'])
+    return JSON.parse(info)
+}
+
+async function get_npm_lts_version_of (name) {
+    let info = await get_npm_info(name)
+    version  = info['dist-tags'].lts
+    return version
+}
+
+module.exports = {section,run,run_read,check_version,get_npm_info,get_npm_lts_version_of,with_cwd}

--- a/build/run.js
+++ b/build/run.js
@@ -210,7 +210,7 @@ commands.watch.rust = async function(argv) {
     let build_args = []
     if (argv.crate != undefined) { build_args.push(`--crate=${argv.crate}`) }
     build_args  = build_args.join(' ')
-    let target  = '"' + `node ${paths.script.main} build --no-js --dev ${build_args} -- ` + cargoArgs.join(" ") + '"'
+    let target  = '"' + `node ${paths.script.main} --no-validation build --no-js --dev ${build_args} -- ` + cargoArgs.join(" ") + '"'
     let args    = ['watch','-s',`${target}`]
     await cmd.with_cwd(paths.rust.root, async () => {
         await cmd.run('cargo',args)

--- a/build/run.js
+++ b/build/run.js
@@ -210,7 +210,7 @@ commands.watch.rust = async function(argv) {
     let build_args = []
     if (argv.crate != undefined) { build_args.push(`--crate=${argv.crate}`) }
     build_args  = build_args.join(' ')
-    let target  = '"' + `node ${paths.script.main} --no-validation build --no-js --dev ${build_args} -- ` + cargoArgs.join(" ") + '"'
+    let target  = '"' + `node ${paths.script.main} --skip-version-validation build --no-js --dev ${build_args} -- ` + cargoArgs.join(" ") + '"'
     let args    = ['watch','-s',`${target}`]
     await cmd.with_cwd(paths.rust.root, async () => {
         await cmd.run('cargo',args)

--- a/run
+++ b/run
@@ -9,10 +9,11 @@ process.on('unhandledRejection', error => { throw(error) })
 
 let args = process.argv.slice(2)
 
-let no_validation = '--no-validation'
+let skip_validation = '--skip-version-validation'
 async function init () {
-    if(!args.includes(no_validation)) {
+    if(!args.includes(skip_validation)) {
         cmd.section('Version Validation')
+        console.log("Use the `" + skip_validation + "` flag to skip it.")
         console.log("Querying npm for the latest LTS versions.")
         let node_lts_version = await cmd.get_npm_lts_version_of('node')
         let npm_lts_version  = await cmd.get_npm_lts_version_of('npm')

--- a/run
+++ b/run
@@ -12,10 +12,15 @@ let args = process.argv.slice(2)
 let no_validation = '--no-validation'
 async function init () {
     if(!args.includes(no_validation)) {
-        await cmd.check_version('node','v12.19.0',{silent:true})
-        await cmd.check_version('npm','6.14.8',{silent:true})
+        cmd.section('Version Validation')
+        console.log("Querying npm for the latest LTS versions.")
+        let node_lts_version = await cmd.get_npm_lts_version_of('node')
+        let npm_lts_version  = await cmd.get_npm_lts_version_of('npm')
+        console.log("Checking versions of installed packages.")
+        await cmd.check_version('node',`v${node_lts_version}`)
+        await cmd.check_version('npm',npm_lts_version)
         await cmd.check_version('rustc','1.40.0-nightly',{
-            preprocess:(v)=>v.substring(6,20),silent:true
+            preprocess:(v)=>v.substring(6,20)
         })
     }
 

--- a/run
+++ b/run
@@ -12,8 +12,8 @@ let args = process.argv.slice(2)
 let no_validation = '--no-validation'
 async function init () {
     if(!args.includes(no_validation)) {
-        await cmd.check_version('node','v12.18.4',{silent:true})
-        await cmd.check_version('npm','6.14.6',{silent:true})
+        await cmd.check_version('node','v12.19.0',{silent:true})
+        await cmd.check_version('npm','6.14.8',{silent:true})
         await cmd.check_version('rustc','1.40.0-nightly',{
             preprocess:(v)=>v.substring(6,20),silent:true
         })


### PR DESCRIPTION
### Description

This fixes some manual workflow. Instead of defining LTS versions of `node` and `npm` in our run scripts, this downloads the information from NPM registry automatically. The only downside of this solution is that it adds approx `1s - 2s` to every `./run` command execution, which should not be a big deal, as we have the `watch` command which skips this check.