### PR TITLE
Fix traversing Seq pattern

### DIFF
--- a/src/rust/ide/lib/span-tree/src/generate/macros.rs
+++ b/src/rust/ide/lib/span-tree/src/generate/macros.rs
@@ -70,8 +70,8 @@ impl<'a> PatternDfs<'a> {
             Or(pat)     => self.push_child_to_visit(&pattern,&pat.elem,PatternMatchCrumb::Or),
             Seq(pat)    => {
                 let (left_elem,right_elem) = &pat.elem;
-                self.push_child_to_visit(&pattern,left_elem ,PatternMatchCrumb::Seq{right:false});
                 self.push_child_to_visit(&pattern,right_elem,PatternMatchCrumb::Seq{right:true});
+                self.push_child_to_visit(&pattern,left_elem ,PatternMatchCrumb::Seq{right:false});
             },
             Many(pat) => {
                 for (index,elem) in pat.elem.iter().enumerate().rev() {


### PR DESCRIPTION
### Pull Request Description
The subpatterns of Seq were traversed backwards.

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/main/docs/style-guide/rust.md) style guide.
- [x] All code has been tested where possible.
- [x] All code has been profiled where possible.

