### PR TITLE
Fix ExpectedArguments SpanTree Nodes in Infix

### DIFF
--- a/docs/product/shortcuts.md
+++ b/docs/product/shortcuts.md
@@ -91,7 +91,7 @@ further investigation.
 | -------- | ------ |
 | <kbd>space</kbd>                         | Toggle visualization visibility of the selected node. |
 | <kbd>space</kbd> hold                    | Preview visualization of the selected node (hide on release). |
-| <kbd>space</kbd> double press            | Toggle visualization fullscreen mode (with improper depth sorting now). |
+| :warning: <kbd>space</kbd> double press  | Toggle visualization fullscreen mode |
 | <kbd>ctrl</kbd> + <kbd>space</kbd>       | Cycle visualizations of the selected node. |
 | :bangbang: <kbd>cmd</kbd> + <kbd>\</kbd> | Toggle documentation view visibility |
 

--- a/src/rust/ide/lib/span-tree/src/generate.rs
+++ b/src/rust/ide/lib/span-tree/src/generate.rs
@@ -164,7 +164,7 @@ fn generate_node_for_ast<T:Payload>
         let chain      = infix.flatten();
         let app_base   = ApplicationBase::new(ast);
         let invocation = || -> Option<CalledMethodInfo> {
-            context.call_info(ast.id?, app_base.function_name)
+            context.call_info(ast.id?, Some(app_base.function_name?))
         }();
 
         // All prefix params are missing arguments, since there is no prefix application.

--- a/src/rust/ide/src/tests.rs
+++ b/src/rust/ide/src/tests.rs
@@ -111,7 +111,7 @@ fn span_tree_args() {
         // an additional prefix application argument.
         [_,second] => {
             let Node{children,kind,..} = &second.node;
-            let expected_kind = node::Kind::insertion_point()
+            let _expected_kind = node::Kind::insertion_point()
                 .with_kind(InsertionPointType::ExpectedArgument(0));
             assert!(children.is_empty());
             // assert_eq!(kind,&node::Kind::from(expected_kind));

--- a/src/rust/ide/view/graph-editor/src/lib.rs
+++ b/src/rust/ide/view/graph-editor/src/lib.rs
@@ -1573,7 +1573,7 @@ impl application::View for GraphEditor {
 
           // === Visualization ===
           , (Press       , "!node_editing" , "space" , "press_visualization_visibility")
-          , (DoublePress , "!node_editing" , "space" , "double_press_visualization_visibility")
+          // , (DoublePress , "!node_editing" , "space" , "double_press_visualization_visibility")
           , (Release     , "!node_editing" , "space" , "release_visualization_visibility")
 
           // === Selection ===


### PR DESCRIPTION
### Pull Request Description
Before if we received MethodCall about operator we always added ExpectedArgument InsertionType to SpanTree.

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/main/docs/style-guide/rust.md) style guide.
- [x] All code has been tested where possible.
- [x] All code has been profiled where possible.

