### PR TITLE
Correctly propagate project name updates from `Breadcrumbs` to `ProjectName`.

### DIFF
--- a/src/rust/ide/view/graph-editor/src/component/breadcrumbs.rs
+++ b/src/rust/ide/view/graph-editor/src/component/breadcrumbs.rs
@@ -399,7 +399,7 @@ impl Breadcrumbs {
 
             // === Project Name ===
 
-            eval frp.input.project_name((name) model.project_name.name(name));
+            eval frp.input.project_name((name) model.project_name.set_name.emit(name));
             frp.source.project_name <+ model.project_name.output.name;
 
 

--- a/src/rust/ide/view/graph-editor/src/component/breadcrumbs.rs
+++ b/src/rust/ide/view/graph-editor/src/component/breadcrumbs.rs
@@ -399,8 +399,8 @@ impl Breadcrumbs {
 
             // === Project Name ===
 
-            eval frp.project_name((name) model.project_name.frp.name(name));
-            frp.source.project_name <+ model.project_name.frp.output.name;
+            eval frp.input.project_name((name) model.project_name.name(name));
+            frp.source.project_name <+ model.project_name.output.name;
 
 
             // === GUI Update ===

--- a/src/rust/ide/view/graph-editor/src/component/breadcrumbs/project_name.rs
+++ b/src/rust/ide/view/graph-editor/src/component/breadcrumbs/project_name.rs
@@ -32,7 +32,7 @@ use logger::enabled::Logger;
 
 // Project name used as a placeholder in `ProjectName` view when it's initialized.
 // This should never be visible, but if it is we want to easily trace it back here.
-const UNINITIALISED_PROJECT_NAME: &str = "Project Name Uninitialised";
+const UNINITIALIZED_PROJECT_NAME: &str = "Project Name Uninitialized";
 /// Default line height for project names.
 pub const LINE_HEIGHT          : f32  = TEXT_SIZE * 1.5;
 
@@ -334,7 +334,7 @@ impl ProjectName {
         }
 
         frp.deselect();
-        frp.input.set_name.emit(UNINITIALISED_PROJECT_NAME.to_string());
+        frp.input.set_name.emit(UNINITIALIZED_PROJECT_NAME.to_string());
 
         Self{frp,model}
     }

--- a/src/rust/ide/view/graph-editor/src/component/breadcrumbs/project_name.rs
+++ b/src/rust/ide/view/graph-editor/src/component/breadcrumbs/project_name.rs
@@ -62,7 +62,7 @@ mod background {
 ensogl::define_endpoints! {
     Input {
        /// Set the project name.
-       name (String),
+       set_name (String),
        /// Reset the project name to the one before editing.
        cancel_editing (),
        /// Commit current project name.
@@ -283,8 +283,8 @@ impl ProjectName {
             // === Input Commands ===
 
             eval_ frp.input.cancel_editing(model.reset_name());
-            eval  frp.input.name((name) {model.rename(name)});
-            frp.output.source.name <+ frp.input.name;
+            eval  frp.input.set_name((name) {model.rename(name)});
+            frp.output.source.name <+ frp.input.set_name;
 
 
             // === Commit ===
@@ -334,7 +334,7 @@ impl ProjectName {
         }
 
         frp.deselect();
-        frp.input.name(UNINITIALISED_PROJECT_NAME.to_string());
+        frp.input.set_name.emit(UNINITIALISED_PROJECT_NAME.to_string());
 
         Self{frp,model}
     }

--- a/src/rust/ide/view/graph-editor/src/component/breadcrumbs/project_name.rs
+++ b/src/rust/ide/view/graph-editor/src/component/breadcrumbs/project_name.rs
@@ -30,8 +30,9 @@ use logger::enabled::Logger;
 // === Constants ===
 // =================
 
-/// Project name used as a placeholder in `ProjectName` view when it's initialized.
-pub const UNKNOWN_PROJECT_NAME : &str = "Unknown";
+// Project name used as a placeholder in `ProjectName` view when it's initialized.
+// This should never be visible, but if it is we want to easily trace it back here.
+const UNINITIALISED_PROJECT_NAME: &str = "Project Name Uninitialised";
 /// Default line height for project names.
 pub const LINE_HEIGHT          : f32  = TEXT_SIZE * 1.5;
 
@@ -148,7 +149,7 @@ impl ProjectNameModel {
         scene.views.main.remove_shape_view(&view);
         scene.views.breadcrumbs.add_shape_view(&view);
 
-        let project_name          = Rc::new(RefCell::new(UNKNOWN_PROJECT_NAME.to_string()));
+        let project_name          = default();
         Self{app,logger,view,style,display_object,text_field,project_name}.init()
     }
 
@@ -198,6 +199,7 @@ impl ProjectNameModel {
 
     fn rename(&self, name:impl Str) {
         let name = name.into();
+        debug!(self.logger, "Renaming: '{name}'.");
         self.update_text_field_content(&name);
     }
 
@@ -332,6 +334,7 @@ impl ProjectName {
         }
 
         frp.deselect();
+        frp.input.name(UNINITIALISED_PROJECT_NAME.to_string());
 
         Self{frp,model}
     }

--- a/src/rust/ide/view/graph-editor/src/component/breadcrumbs/project_name.rs
+++ b/src/rust/ide/view/graph-editor/src/component/breadcrumbs/project_name.rs
@@ -30,8 +30,9 @@ use logger::enabled::Logger;
 // === Constants ===
 // =================
 
-// Project name used as a placeholder in `ProjectName` view when it's initialized.
-// This should never be visible, but if it is we want to easily trace it back here.
+// This is a default value for the project name when it is created. The project name should
+// always be initialized externally for the current project. If this value is visible in the UI,
+// it was not set to the correct project name due to some bug.
 const UNINITIALIZED_PROJECT_NAME: &str = "Project Name Uninitialized";
 /// Default line height for project names.
 pub const LINE_HEIGHT          : f32  = TEXT_SIZE * 1.5;


### PR DESCRIPTION
### Pull Request Description
The FRP from the `Breadcrumbs` was incorrectly connected to the FRP of the `ProjectName` and updates were not propagated correctly. This PR fixes that. It also ensures an uninitialised project name (which should never happen) is more visible by changing the default text to something more obvious. 

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/main/docs/style-guide/rust.md) style guide.
- [x] All code has been tested where possible.
- [x] All code has been profiled where possible.

