### PR TITLE
Avoid the visualisation container background showing up when loading the scene or collapsing some nodes.

### DIFF
--- a/src/rust/ide/view/graph-editor/src/component/visualization/container.rs
+++ b/src/rust/ide/view/graph-editor/src/component/visualization/container.rs
@@ -607,9 +607,10 @@ impl Container {
 
         // FIXME[mm]: If we set the size right here, we will see spurious shapes in some
         // computation heavy circumstances (e.g., collapsing nodes #805, or creating an new project
-        // #761).
-        // If we leave use the frp api and don't abort the animation, the size will stay at (0,0)
-        // until the animation has run its course and the shape stays invisible during loads.
+        // #761). This should not happen anyway, but the following is a hotfix to hide the visible
+        // behaviour. If we leave use the frp api and don't abort the animation, the size will stay
+        // at (0,0) until the animation has run its course and the shape stays invisible during
+        // loads.
         //
         // The order of events is like this:
         // * shape gets created (with size 0 or default size).

--- a/src/rust/ide/view/graph-editor/src/component/visualization/container.rs
+++ b/src/rust/ide/view/graph-editor/src/component/visualization/container.rs
@@ -603,8 +603,17 @@ impl Container {
         }
 
         // FIXME[mm]: If we set the size right here, we will see spurious shapes in some
-        // computation heavy circumstances (e.g., collapsing nodes, or creating an new project).
-        // If we let the animation do the size change, the size will only be set after the delays.
+        // computation heavy circumstances (e.g., collapsing nodes #805, or creating an new project
+        // #761).
+        // If we leave use the frp api and don't abort the animation, the size will stay at (0,0)
+        // until the animation has run its course and the shape stays invisible during loads.
+        //
+        // The order of events is like this:
+        // * shape gets created (with size 0 or default size).
+        // * some load happens in the scene, the shape is visible if it has a non-zero size.
+        // * load is resolved and the shape is hidden as it should be.
+        // * the animation finishes running and sets the size to the correct size.
+        //
         // This is not optimal the optimal solution to this problem, as it also means that we have
         // an animation on an invisible component running.
         frp.set_size.emit(Vector2(DEFAULT_SIZE.0,DEFAULT_SIZE.1));

--- a/src/rust/ide/view/graph-editor/src/component/visualization/container.rs
+++ b/src/rust/ide/view/graph-editor/src/component/visualization/container.rs
@@ -602,8 +602,12 @@ impl Container {
             eval_ on_selected ( action_bar.hide_icons.emit(()) );
         }
 
+        // FIXME[mm]: If we set the size right here, we will see spurious shapes in some
+        // computation heavy circumstances (e.g., collapsing nodes, or creating an new project).
+        // If we let the animation do the size change, the size will only be set after the delays.
+        // This is not optimal the optimal solution to this problem, as it also means that we have
+        // an animation on an invisible component running.
         frp.set_size.emit(Vector2(DEFAULT_SIZE.0,DEFAULT_SIZE.1));
-        size.skip();
         frp.set_visualization.emit(Some(visualization::Registry::default_visualisation()));
         self
     }


### PR DESCRIPTION
### Pull Request Description
Avoids the background of the visualization container showing up when a new node is created on startup and when collapsing nodes.

### Important Notes
This is not a great solution. It fixes the symptom but it does probably not address the root cause of this issue. I'm not sure what exactly the root cause is, but I suspect some parenting issue. Unfortunately, I have not yet been able to pinpoint a specific fix or reproducible bug regarding the order of parenting of all the shapes involved.  

Maybe this might even be involved to #761?  (I don't see the behaviour there, but I see the empty container showing up instead)

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/main/docs/style-guide/rust.md) style guide.
- [x] All code has been tested where possible.
- [x] All code has been profiled where possible.

