### PR TITLE
Display Searcher under selected nodes

### DIFF
--- a/src/rust/ide/src/view/integration.rs
+++ b/src/rust/ide/src/view/integration.rs
@@ -127,7 +127,7 @@ const COLLAPSED_FUNCTION_NAME:&str = "func";
 
 /// The gap between nodes in pixels on default node layout (when user did not set any position of
 /// node - possibly when node was added by editing text).
-const DEFAULT_GAP_BETWEEN_NODES : f32 = 40.0;
+const DEFAULT_GAP_BETWEEN_NODES : f32 = ide_view::project::NEW_NODE_Y_GAP;
 /// The default X position of the node when user did not set any position of node - possibly when
 /// node was added by editing text.
 const DEFAULT_NODE_X_POSITION   : f32 = -100.0;

--- a/src/rust/ide/view/graph-editor/src/lib.rs
+++ b/src/rust/ide/view/graph-editor/src/lib.rs
@@ -103,6 +103,11 @@ impl<T> SharedVec<T> {
         self.raw.borrow().contains(t)
     }
 
+    /// Return clone of the first element of the slice, or `None` if it is empty.
+    pub fn first_cloned(&self) -> Option<T> where T:Clone {
+        self.raw.borrow().first().cloned()
+    }
+
     /// Return clone of the last element of the slice, or `None` if it is empty.
     pub fn last_cloned(&self) -> Option<T> where T:Clone {
         self.raw.borrow().last().cloned()
@@ -1588,10 +1593,10 @@ impl application::View for GraphEditor {
           , (Release , "" , "shift ctrl alt" , "toggle_node_inverse_select")
 
           // === Navigation ===
-          , (Press       , "" , "ctrl space"        , "cycle_visualization_for_selected_node")
-          , (DoublePress , "" , "left-mouse-button" , "enter_selected_node")
-          , (Press       , "" , "enter"             , "enter_selected_node")
-          , (Press       , "" , "alt enter"         , "exit_node")
+          , (Press       , ""              , "ctrl space"        , "cycle_visualization_for_selected_node")
+          , (DoublePress , ""              , "left-mouse-button" , "enter_selected_node")
+          , (Press       , "!node_editing" , "enter"             , "enter_selected_node")
+          , (Press       , ""              , "alt enter"         , "exit_node")
 
           // === Node Editing ===
           , (Press   , "" , "cmd"                   , "edit_mode_on")
@@ -1846,7 +1851,7 @@ fn new_graph_editor(app:&Application) -> GraphEditor {
     edit_mode               <- bool(&inputs.edit_mode_off,&inputs.edit_mode_on);
     node_to_select_non_edit <- touch.nodes.selected.gate_not(&edit_mode);
     node_to_select_edit     <- touch.nodes.down.gate(&edit_mode);
-    node_to_select          <- any(&node_to_select_non_edit,&node_to_select_edit);
+    node_to_select          <- any(node_to_select_non_edit,node_to_select_edit,inputs.select_node);
     node_was_selected       <- node_to_select.map(f!((id) model.nodes.selected.contains(id)));
 
     should_select <- node_to_select.map3(&selection_mode,&node_was_selected,


### PR DESCRIPTION
### Pull Request Description
Before searcher brought by pressing Tab was always displayed under the mouse pointer. Now, if there are nodes selected, it will go under the selected node instead. Additionally, the newly created node is always selected.

There is also a fix for aborting adding/editing node.

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/main/docs/style-guide/rust.md) style guide.
- [x] All code has been tested where possible.
- [x] All code has been profiled where possible.

