### PR TITLE
Add background to js visualisation.

### DIFF
--- a/src/js/lib/content/src/index.html
+++ b/src/js/lib/content/src/index.html
@@ -69,6 +69,7 @@
 
             .visualization {
                 z-index: 2;
+                border-radius: 14px;
             }
         </style>
         <script type="module" src="/assets/index.js" defer></script>

--- a/src/js/lib/content/src/index.html
+++ b/src/js/lib/content/src/index.html
@@ -70,6 +70,7 @@
             .visualization {
                 z-index: 2;
                 border-radius: 14px;
+                box-shadow: 0 0 10px hsla(0, 0%, 0%, 0.1);
             }
         </style>
         <script type="module" src="/assets/index.js" defer></script>

--- a/src/rust/ide/view/graph-editor/src/builtin/visualization/native/raw_text.rs
+++ b/src/rust/ide/view/graph-editor/src/builtin/visualization/native/raw_text.rs
@@ -89,10 +89,14 @@ impl RawTextModel {
         let _red       = text_color.red * 255.0;
         let _green     = text_color.green * 255.0;
         let _blue      = text_color.blue * 255.0;
+
+        let bg_color   = styles.get_color(ensogl_theme::vars::graph_editor::visualization::background::color);
+        let bg_color   = color::Rgba::from(bg_color);
         let text_color = format!("rgba({},{},{},{})",_red,_green,_blue,text_color.alpha);
+        let bg_hex     = format!("rgba({},{},{},{})",bg_color.red*255.0,bg_color.green*255.0,bg_color.blue*255.0,bg_color.alpha);
 
         dom.dom().set_attribute_or_warn("class","visualization scrollable",&logger);
-
+        dom.dom().set_style_or_warn("background"    ,bg_hex          ,&logger);
         dom.dom().set_style_or_warn("white-space"   ,"pre"           ,&logger);
         dom.dom().set_style_or_warn("overflow-y"    ,"auto"          ,&logger);
         dom.dom().set_style_or_warn("overflow-x"    ,"auto"          ,&logger);

--- a/src/rust/ide/view/graph-editor/src/builtin/visualization/native/raw_text.rs
+++ b/src/rust/ide/view/graph-editor/src/builtin/visualization/native/raw_text.rs
@@ -93,7 +93,11 @@ impl RawTextModel {
         let bg_color   = styles.get_color(ensogl_theme::vars::graph_editor::visualization::background::color);
         let bg_color   = color::Rgba::from(bg_color);
         let text_color = format!("rgba({},{},{},{})",_red,_green,_blue,text_color.alpha);
-        let bg_hex     = format!("rgba({},{},{},{})",bg_color.red*255.0,bg_color.green*255.0,bg_color.blue*255.0,bg_color.alpha);
+
+        let bg_red   = bg_color.red*255.0;
+        let bg_green = bg_color.green*255.0;
+        let bg_blue  = bg_color.blue*255.0;
+        let bg_hex   = format!("rgba({},{},{},{})",bg_red,bg_green,bg_blue,bg_color.alpha);
 
         dom.dom().set_attribute_or_warn("class","visualization scrollable",&logger);
         dom.dom().set_style_or_warn("background"    ,bg_hex          ,&logger);

--- a/src/rust/ide/view/graph-editor/src/component/visualization/container.rs
+++ b/src/rust/ide/view/graph-editor/src/component/visualization/container.rs
@@ -41,7 +41,7 @@ use ensogl_theme as theme;
 
 const DEFAULT_SIZE      : (f32,f32) = (200.0,200.0);
 const CORNER_RADIUS     : f32       = super::super::node::CORNER_RADIUS;
-const SHADOW_SIZE       : f32       = super::super::node::SHADOW_SIZE;
+const SHADOW_SIZE       : f32       = 0.0 * super::super::node::SHADOW_SIZE;
 const ACTION_BAR_HEIGHT : f32       = 2.0 * CORNER_RADIUS;
 
 

--- a/src/rust/ide/view/graph-editor/src/component/visualization/container.rs
+++ b/src/rust/ide/view/graph-editor/src/component/visualization/container.rs
@@ -41,8 +41,11 @@ use ensogl_theme as theme;
 
 const DEFAULT_SIZE      : (f32,f32) = (200.0,200.0);
 const CORNER_RADIUS     : f32       = super::super::node::CORNER_RADIUS;
+// Note[mm]: at the moment we use a CSS replacement shadow defined in the .visualization class of
+// `src/js/lib/content/src/index.html`. While that is in use this shadow is deactivated.
 const SHADOW_SIZE       : f32       = 0.0 * super::super::node::SHADOW_SIZE;
 const ACTION_BAR_HEIGHT : f32       = 2.0 * CORNER_RADIUS;
+
 
 
 // =============

--- a/src/rust/ide/view/graph-editor/src/component/visualization/foreign/java_script/instance.rs
+++ b/src/rust/ide/view/graph-editor/src/component/visualization/foreign/java_script/instance.rs
@@ -98,8 +98,8 @@ pub struct InstanceModel {
 impl InstanceModel {
 
     fn get_background_color(scene:&Scene) -> color::Rgba {
-        let styles     = StyleWatch::new(&scene.style_sheet);
-        let bg_color   = styles.get_color(ensogl_theme::vars::graph_editor::visualization::background::color);
+        let styles   = StyleWatch::new(&scene.style_sheet);
+        let bg_color = styles.get_color(ensogl_theme::vars::graph_editor::visualization::background::color);
         color::Rgba::from(bg_color)
     }
 
@@ -110,7 +110,10 @@ impl InstanceModel {
             .map_err(|js_error|Error::ConstructorError{js_error})?;
 
         let bg_color = Self::get_background_color(scene);
-        let bg_hex     = format!("rgba({},{},{},{})",bg_color.red*255.0,bg_color.green*255.0,bg_color.blue*255.0,bg_color.alpha);
+        let bg_red   = bg_color.red*255.0;
+        let bg_green = bg_color.green*255.0;
+        let bg_blue  = bg_color.blue*255.0;
+        let bg_hex   = format!("rgba({},{},{},{})",bg_red,bg_green,bg_blue,bg_color.alpha);
         root_node.dom().set_style_or_warn("background",bg_hex,logger);
 
         Ok(root_node)

--- a/src/rust/ide/view/graph-editor/src/component/visualization/foreign/java_script/instance.rs
+++ b/src/rust/ide/view/graph-editor/src/component/visualization/foreign/java_script/instance.rs
@@ -16,15 +16,17 @@ use crate::component::visualization;
 
 use core::result;
 use enso_frp as frp;
+use ensogl::data::color;
 use ensogl::display::DomScene;
 use ensogl::display::DomSymbol;
 use ensogl::display::Scene;
+use ensogl::display::shape::StyleWatch;
 use ensogl::display;
-use ensogl::system::web;
 use ensogl::system::web::JsValue;
+use ensogl::system::web;
+use ensogl::system::web::StyleSetter;
 use js_sys;
 use std::fmt::Formatter;
-
 
 
 // ==============
@@ -95,11 +97,22 @@ pub struct InstanceModel {
 
 impl InstanceModel {
 
-    fn create_root() -> result::Result<DomSymbol, Error> {
+    fn get_background_color(scene:&Scene) -> color::Rgba {
+        let styles     = StyleWatch::new(&scene.style_sheet);
+        let bg_color   = styles.get_color(ensogl_theme::vars::graph_editor::visualization::background::color);
+        color::Rgba::from(bg_color)
+    }
+
+    fn create_root(scene:&Scene,logger:&Logger) -> result::Result<DomSymbol, Error> {
         let div       = web::create_div();
         let root_node = DomSymbol::new(&div);
         root_node.dom().set_attribute("class","visualization")
             .map_err(|js_error|Error::ConstructorError{js_error})?;
+
+        let bg_color = Self::get_background_color(scene);
+        let bg_hex     = format!("rgba({},{},{},{})",bg_color.red*255.0,bg_color.green*255.0,bg_color.blue*255.0,bg_color.alpha);
+        root_node.dom().set_style_or_warn("background",bg_hex,logger);
+
         Ok(root_node)
     }
 
@@ -136,8 +149,9 @@ impl InstanceModel {
     }
 
     /// Tries to create a InstanceModel from the given visualisation class.
-    pub fn from_class(class:&JsValue) -> result::Result<Self, Error> {
-        let root_node                     = Self::create_root()?;
+    pub fn from_class(class:&JsValue,scene:&Scene) -> result::Result<Self, Error> {
+        let logger                        = Logger::new("Instance");
+        let root_node                     = Self::create_root(scene,&logger)?;
         let (preprocessor_change,closure) = Self::preprocessor_change_callback();
         let init_data                     = JsConsArgs::new(root_node.clone_ref(), closure);
         let object                        = Self::instantiate_class_with_args(class,init_data)?;
@@ -145,7 +159,6 @@ impl InstanceModel {
         let on_data_received              = Rc::new(on_data_received);
         let set_size                      = get_method(&object,method::SET_SIZE).ok();
         let set_size                      = Rc::new(set_size);
-        let logger                        = Logger::new("Instance");
         let object                        = Rc::new(object);
         Ok(InstanceModel{object,on_data_received,set_size,root_node,logger,preprocessor_change})
     }
@@ -213,7 +226,7 @@ impl Instance {
     pub fn new(class:&JsValue, scene:&Scene) -> result::Result<Instance, Error>  {
         let network = default();
         let frp     = visualization::instance::Frp::new(&network);
-        let model   = InstanceModel::from_class(class)?;
+        let model   = InstanceModel::from_class(class,scene)?;
         model.set_dom_layer(&scene.dom.layers.back);
         Ok(Instance{model,frp,network}.init_frp(&scene).inti_preprocessor_change_callback())
     }


### PR DESCRIPTION
### Pull Request Description

Avoids overlapping JS visualizations adding a background.
This fixes some occlusion issues.

### Important Notes
This in only a partial solution to #867, proper solution requires #913 to be finalized and implemented.

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/main/docs/style-guide/rust.md) style guide.
- [x] All code has been tested where possible.
- [x] All code has been profiled where possible.

