### PR TITLE
Fixes visualizations when using Enso's builtin JSON parser

### DIFF
--- a/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/mapView.js
+++ b/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/mapView.js
@@ -62,7 +62,10 @@ class MapViewVisualization extends Visualization {
         mapElem.setAttributeNS(null,"style","width:" + width + "px;height: " + height + "px;");
         this.dom.appendChild(mapElem);
 
-        const parsedData = eval('('+data+')' ) || JSON.parse(data);
+        let parsedData = data;
+        if (typeof data === "string") {
+            parsedData = JSON.parse(data);
+        }
 
         let defaultMapStyle = 'mapbox://styles/mapbox/light-v9';
         if (document.getElementById("root").classList.contains("dark")){

--- a/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/mapView.js
+++ b/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/mapView.js
@@ -62,12 +62,18 @@ class MapViewVisualization extends Visualization {
         mapElem.setAttributeNS(null,"style","width:" + width + "px;height: " + height + "px;");
         this.dom.appendChild(mapElem);
 
-        const parsedData = eval('('+data+')' );
+        const parsedData = eval('('+data+')' ) || JSON.parse(data);
+
+        let defaultMapStyle = 'mapbox://styles/mapbox/light-v9';
+        if (document.getElementById("root").classList.contains("dark")){
+            defaultMapStyle = 'mapbox://styles/mapbox/dark-v9';
+        }
+
 
         const deckgl = new deck.DeckGL({
             container: 'map',
             mapboxApiAccessToken: 'pk.eyJ1IjoiZW5zby1vcmciLCJhIjoiY2tmNnh5MXh2MGlyOTJ5cWdubnFxbXo4ZSJ9.3KdAcCiiXJcSM18nwk09-Q',
-            mapStyle: parsedData.mapStyle || 'mapbox://styles/mapbox/light-v9',
+            mapStyle: parsedData.mapStyle || defaultMapStyle,
             initialViewState: {
                 longitude: parsedData.longitude || 0.0,
                 latitude: parsedData.latitude || 0.0,

--- a/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/scatterPlot.js
+++ b/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/scatterPlot.js
@@ -91,7 +91,7 @@ class ScatterPlot extends Visualization {
         this.dom.appendChild(divElem);
 
         let parsedData = data;
-        if (typeof text === "string") {
+        if (typeof data === "string") {
             parsedData = JSON.parse(data);
         }
         let axis       = parsedData.axis || {x:{scale:linear_scale},y:{scale:linear_scale}};

--- a/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/scatterPlot.js
+++ b/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/scatterPlot.js
@@ -90,7 +90,10 @@ class ScatterPlot extends Visualization {
         const divElem       = this.createDivElem(width,height);
         this.dom.appendChild(divElem);
 
-        let parsedData = JSON.parse(data);
+        let parsedData = data;
+        if (typeof text === "string") {
+            parsedData = JSON.parse(data);
+        }
         let axis       = parsedData.axis || {x:{scale:linear_scale},y:{scale:linear_scale}};
         let focus      = parsedData.focus;
         let points     = parsedData.points || {labels:"invisible"};

--- a/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/tableView.js
+++ b/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/tableView.js
@@ -233,10 +233,17 @@ class TableViewVisualization extends Visualization {
         tabElem.setAttributeNS(null,"style"  ,tblViewStyle);
         this.dom.appendChild(tabElem);
 
-        let parsedData    = JSON.parse(data);
-        let table         = genTable(parsedData.data || parsedData, 0, parsedData.header);
-        tabElem.innerHTML = style_light + table;
+        let parsedData = data;
+        if (typeof text === "string") {
+            parsedData = JSON.parse(data);
+        }
 
+        let style = style_light
+        if (document.getElementById("root").classList.contains("dark")){
+            style = style_dark + table;
+        }
+        let table         = genTable(parsedData.data || parsedData, 0, parsedData.header);
+        tabElem.innerHTML = style + table;
     }
 
     setSize(size) {

--- a/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/tableView.js
+++ b/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/tableView.js
@@ -234,7 +234,7 @@ class TableViewVisualization extends Visualization {
         this.dom.appendChild(tabElem);
 
         let parsedData = data;
-        if (typeof text === "string") {
+        if (typeof data === "string") {
             parsedData = JSON.parse(data);
         }
 


### PR DESCRIPTION
## Pull Request Description
<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->
As @sylwiabr found out today, table view didn't work on Tram's playground, and that was because visualization was trying to parse an already parsed object with Enso's builtin parser. Fixes the fact and also fixes it on other two visualizations.

### Important Notes
<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist
Please include the following checklist in your PR:

- [ ] The documentation has been updated if necessary.
- [ ] All code conforms to the [Rust](https://github.com/luna/enso/blob/main/docs/style-guide/rust.md) style guide.
- [ ] All code has been tested where possible.
- [ ] All code has been profiled where possible.

