### PR TITLE
Put here keyword instead of module name

### DIFF
--- a/build/run.js
+++ b/build/run.js
@@ -135,7 +135,7 @@ commands.build.rust = async function(argv) {
 
         console.log('Checking the resulting WASM size.')
         let stats = fss.statSync(paths.dist.wasm.mainOptGz)
-        let limit = 4.12
+        let limit = 4.13
         let size = Math.round(100 * stats.size / 1024 / 1024) / 100
         if (size > limit) {
             throw(`Output file size exceeds the limit (${size}MB > ${limit}MB).`)

--- a/src/rust/ide/src/controller/searcher/suggestion.rs
+++ b/src/rust/ide/src/controller/searcher/suggestion.rs
@@ -3,6 +3,7 @@
 use crate::prelude::*;
 
 
+
 // ===================
 // === Suggestion ===
 // ===================
@@ -22,7 +23,7 @@ impl Suggestion {
     /// The suggestion caption (suggested function name, or action name, etc.).
     pub fn caption(&self) -> String {
         match self {
-            Self::Completion(completion) => completion.code_to_insert(None)
+            Self::Completion(completion) => completion.code_to_insert(None,None)
         }
     }
 }

--- a/src/rust/ide/src/view/integration.rs
+++ b/src/rust/ide/src/view/integration.rs
@@ -1135,7 +1135,7 @@ impl DataProviderForView {
             EntryKind::Local    => "Local variable",
             EntryKind::Method   => "Method",
         };
-        format!("{} `{}`\n\nNo documentation available", title,suggestion.code_to_insert(None))
+        format!("{} `{}`\n\nNo documentation available", title,suggestion.code_to_insert(None,None))
     }
 }
 


### PR DESCRIPTION
### Pull Request Description
Searcher by default put module name as this argument when picked module method. However the name sometimes clashes with existing identifier. This is especially problematic in Main module with function main defined.

To avoid most common problem, the searcher will put "here" keyword instead of module name if the function chosen is a current module's method.

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/main/docs/style-guide/rust.md) style guide.
- [x] All code has been tested where possible.
- [x] All code has been profiled where possible.

