### PR TITLE
Fix GeoMaps on Enso types or JSON data.

### DIFF
--- a/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/mapView.js
+++ b/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/mapView.js
@@ -79,7 +79,7 @@ class MapViewVisualization extends Visualization {
             initialViewState: {
                 longitude: parsedData.longitude || 0.0,
                 latitude: parsedData.latitude || 0.0,
-                zoom: parsedData.zoom || 3,
+                zoom: parsedData.zoom || 9,
                 pitch: parsedData.pitch || 0
             },
             controller: parsedData.controller || true

--- a/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/mapView.js
+++ b/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/mapView.js
@@ -102,13 +102,13 @@ class MapViewVisualization extends Visualization {
             getRadius:d => d.radius
         })
 
-        let latitude   = this.ok(parsedData.latitude)   ? parsedData.latitude : computed.latitude;
-        let longitude  = this.ok(parsedData.longitude)  ? parsedData.longitude : computed.longitude;
+        let latitude   = ok(parsedData.latitude)   ? parsedData.latitude : computed.latitude;
+        let longitude  = ok(parsedData.longitude)  ? parsedData.longitude : computed.longitude;
         // TODO : Compute zoom somehow from span of latitudes and longitudes.
-        let zoom       = this.ok(parsedData.zoom)       ? parsedData.zoom : DEFAULT_MAP_ZOOM;
-        let mapStyle   = this.ok(parsedData.mapStyle)   ? parsedData.mapStyle : defaultMapStyle;
-        let pitch      = this.ok(parsedData.pitch)      ? parsedData.pitch : 0;
-        let controller = this.ok(parsedData.controller) ? parsedData.controller : true;
+        let zoom       = ok(parsedData.zoom)       ? parsedData.zoom : DEFAULT_MAP_ZOOM;
+        let mapStyle   = ok(parsedData.mapStyle)   ? parsedData.mapStyle : defaultMapStyle;
+        let pitch      = ok(parsedData.pitch)      ? parsedData.pitch : 0;
+        let controller = ok(parsedData.controller) ? parsedData.controller : true;
 
         const deckgl = new deck.DeckGL({
             container: 'map',
@@ -151,7 +151,7 @@ class MapViewVisualization extends Visualization {
                 const computed = this.calculateExtremesAndPushPoints(parsedData.data,preparedDataPoints,accentColor);
                 latitude       = computed.latitude;
                 longitude      = computed.longitude;
-            } else if (parsedData.type === GEO_MAP && this.ok(parsedData.layers)) {
+            } else if (parsedData.type === GEO_MAP && ok(parsedData.layers)) {
                 parsedData.layers.forEach(layer => {
                     if (layer.type === SCATTERPLOT_LAYER) {
                         let dataPoints = layer.data || [];
@@ -204,15 +204,8 @@ class MapViewVisualization extends Visualization {
     pushGeoPoint(preparedDataPoints,geoPoint,accentColor) {
         let position = [geoPoint.longitude,geoPoint.latitude];
         let radius   = isNaN(geoPoint.radius)  ? DEFAULT_POINT_RADIUS : geoPoint.radius;
-        let color    = this.ok(geoPoint.color) ? geoPoint.color : accentColor;
+        let color    = ok(geoPoint.color) ? geoPoint.color : accentColor;
         preparedDataPoints.push({position,color,radius});
-    }
-
-    /**
-     * Checks if `t` has defined type and is not null.
-     */
-    ok(t) {
-        return t !== undefined && t !== null;
     }
 
     /**
@@ -223,6 +216,13 @@ class MapViewVisualization extends Visualization {
         this.dom.setAttributeNS(null,"width",size[0]);
         this.dom.setAttributeNS(null,"height",size[1]);
     }
+}
+
+/**
+ * Checks if `t` has defined type and is not null.
+ */
+function ok(t) {
+    return t !== undefined && t !== null;
 }
 
 return MapViewVisualization;

--- a/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/mapView.js
+++ b/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/mapView.js
@@ -160,18 +160,22 @@ class MapViewVisualization extends Visualization {
      * @returns {{latitude: number, longitude: number}} - center.
      */
     prepareDataPointsHelper(dataPoints,preparedDataPoints,accentColor) {
-        let latitudes = [];
+        let latitudes  = [];
         let longitudes = [];
         dataPoints.forEach(e => {
-            this.pushGeoPoint(preparedDataPoints, e, accentColor);
+            this.pushGeoPoint(preparedDataPoints,e,accentColor);
             latitudes.push(e.latitude);
             longitudes.push(e.longitude);
         });
-        let latitude = 0.0;
+        let latitude  = 0.0;
         let longitude = 0.0;
         if (latitudes.length && longitudes.length) {
-            latitude = latitudes.reduce((a, b) => a + b) / latitudes.length;
-            longitude = longitudes.reduce((a, b) => a + b) / longitudes.length;
+            let minLat = Math.min.apply(null,latitudes);
+            let maxLat = Math.max.apply(null,latitudes);
+            latitude   = (minLat + maxLat)/2;
+            let minLon = Math.min.apply(null,longitudes);
+            let maxLon = Math.max.apply(null,longitudes);
+            longitude  = (minLon + maxLon)/2;
         }
         return {latitude,longitude};
     }

--- a/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/mapView.js
+++ b/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/mapView.js
@@ -88,14 +88,14 @@ class MapViewVisualization extends Visualization {
             getFillColor: d => d.color,
             getRadius: d => d.radius
         })
-
+        //
         let latitudeMatch  = parsedData.latitude !== undefined && parsedData.latitude !== null;
         let latitude       = latitudeMatch ? parsedData.latitude : computed.latitude;
-        let longitudeMatch = parsedData.latitude !== undefined && parsedData.latitude !== null;
-        let longitude      = longitudeMatch ? parsedData.latitude : computed.longitude;
+        let longitudeMatch = parsedData.longitude !== undefined && parsedData.longitude !== null;
+        let longitude      = longitudeMatch ? parsedData.longitude : computed.longitude;
         // TODO : Compute zoom somehow.
         let zoomMatch      = parsedData.zoom !== undefined && parsedData.zoom !== null;
-        let zoom           = zoomMatch ? parsedData.latitude : computed.zoom;
+        let zoom           = zoomMatch ? parsedData.zoom : computed.zoom;
 
         const deckgl = new deck.DeckGL({
             container: 'map',
@@ -128,24 +128,24 @@ class MapViewVisualization extends Visualization {
 
         if (parsedData.type === GEO_POINT) {
             this.pushGeoPoint(preparedDataPoints,parsedData,accentColor);
-            longitude = parsedData.longitude;
             latitude  = parsedData.latitude;
+            longitude = parsedData.longitude;
         } else if (Array.isArray(parsedData) && parsedData.length && parsedData[0].type === GEO_POINT) {
             const computed    = this.prepareDataPointsHelper(parsedData,preparedDataPoints,accentColor);
-            longitude = computed.latitude;
-            latitude  = computed.longitude;
+            latitude = computed.latitude;
+            longitude  = computed.longitude;
         } else {
             if (parsedData.type === SCATTERPLOT_LAYER && parsedData.data.length) {
                 const computed    = this.prepareDataPointsHelper(parsedData.data,preparedDataPoints,accentColor);
-                longitude = computed.latitude;
-                latitude  = computed.longitude;
+                latitude = computed.latitude;
+                longitude  = computed.longitude;
             } else if (parsedData.type === GEO_MAP && parsedData.layers !== undefined) {
                 parsedData.layers.forEach(layer => {
                     if (layer.type === SCATTERPLOT_LAYER) {
                         let dataPoints    = layer.data || [];
                         const computed    = this.prepareDataPointsHelper(dataPoints,preparedDataPoints,accentColor);
-                        longitude = computed.latitude;
-                        latitude  = computed.longitude;
+                        latitude = computed.latitude;
+                        longitude  = computed.longitude;
                     } else {
                         console.log("Currently unsupported deck.gl layer.")
                     }

--- a/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/mapView.js
+++ b/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/mapView.js
@@ -66,14 +66,11 @@ class MapViewVisualization extends Visualization {
         if (typeof data === "string") {
             parsedData = JSON.parse(data);
         }
-
-        console.log(parsedData);
-
+        
         let defaultMapStyle = 'mapbox://styles/mapbox/light-v9';
         if (document.getElementById("root").classList.contains("dark")){
             defaultMapStyle = 'mapbox://styles/mapbox/dark-v9';
         }
-
 
         const deckgl = new deck.DeckGL({
             container: 'map',
@@ -90,17 +87,16 @@ class MapViewVisualization extends Visualization {
 
         let dataPoints = parsedData.layers[0].data || []
         let preparedDP = []
-        dataPoints.forEach(x => preparedDP.push({position: [x.longitude, x.latitude], color: x.color || [33,33,33], radius:x.radius  || 100}))
+        dataPoints.forEach(x => preparedDP.push({position:[x.longitude,x.latitude], color:x.color || [1,234,146], radius:x.radius || 100}))
         console.log(preparedDP);
 
         const scatterplotLayer = new deck.ScatterplotLayer({
             data: preparedDP,
-            getPosition: d => [d[0], d[1], 0],
-            getColor: d => d.color,
+            getFillColor: d => d.color,
             getRadius: d => d.radius
         })
 
-        if (parsedData.layers[0].type.toLowerCase() === "scatterplotlayer") {
+        if (parsedData.layers[0].type === "ScatterplotLayer") {
             deckgl.setProps({
                 layers: [scatterplotLayer]
             });

--- a/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/mapView.js
+++ b/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/mapView.js
@@ -85,11 +85,11 @@ class MapViewVisualization extends Visualization {
             controller: parsedData.controller || true
         });
 
-        let dataPoints = parsedData.layers[0].data || []
         let preparedDP = []
         if (parsedData.type === "GeoPoint") {
             preparedDP.push({position:[parsedData.longitude,parsedData.latitude], color:parsedData.color || [1,234,146], radius:parsedData.radius || 100});
         } else {
+            let dataPoints = parsedData.layers[0].data || []
             dataPoints.forEach(x => preparedDP.push({position:[x.longitude,x.latitude], color:x.color || [1,234,146], radius:x.radius || 100}));
         }
 

--- a/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/mapView.js
+++ b/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/mapView.js
@@ -122,30 +122,30 @@ class MapViewVisualization extends Visualization {
      * @param accentColor - accent color of IDE if element doesn't specify one.
      */
     prepareDataPoints(parsedData, preparedDataPoints, accentColor) {
-        let computedLatitude   = 0.0;
-        let computedLongitude  = 0.0;
-        let computedZoom       = 11;
+        let latitude  = 0.0;
+        let longitude = 0.0;
+        let zoom      = 11;
 
         if (parsedData.type === GEO_POINT) {
             this.pushGeoPoint(preparedDataPoints,parsedData,accentColor);
-            computedLongitude = parsedData.longitude;
-            computedLatitude  = parsedData.latitude;
+            longitude = parsedData.longitude;
+            latitude  = parsedData.latitude;
         } else if (Array.isArray(parsedData) && parsedData.length && parsedData[0].type === GEO_POINT) {
             const computed    = this.prepareDataPointsHelper(parsedData,preparedDataPoints,accentColor);
-            computedLongitude = computed.latitude;
-            computedLatitude  = computed.longitude;
+            longitude = computed.latitude;
+            latitude  = computed.longitude;
         } else {
             if (parsedData.type === SCATTERPLOT_LAYER && parsedData.data.length) {
                 const computed    = this.prepareDataPointsHelper(parsedData.data,preparedDataPoints,accentColor);
-                computedLongitude = computed.latitude;
-                computedLatitude  = computed.longitude;
+                longitude = computed.latitude;
+                latitude  = computed.longitude;
             } else if (parsedData.type === GEO_MAP && parsedData.layers !== undefined) {
                 parsedData.layers.forEach(layer => {
                     if (layer.type === SCATTERPLOT_LAYER) {
                         let dataPoints    = layer.data || [];
                         const computed    = this.prepareDataPointsHelper(dataPoints,preparedDataPoints,accentColor);
-                        computedLongitude = computed.latitude;
-                        computedLatitude  = computed.longitude;
+                        longitude = computed.latitude;
+                        latitude  = computed.longitude;
                     } else {
                         console.log("Currently unsupported deck.gl layer.")
                     }
@@ -153,7 +153,7 @@ class MapViewVisualization extends Visualization {
             }
         }
 
-        return {computedLatitude,computedLongitude,computedZoom}
+        return {latitude,longitude,zoom}
     }
 
     prepareDataPointsHelper(dataPoints,preparedDataPoints,accentColor) {

--- a/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/mapView.js
+++ b/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/mapView.js
@@ -67,6 +67,8 @@ class MapViewVisualization extends Visualization {
             parsedData = JSON.parse(data);
         }
 
+        console.log(parsedData);
+
         let defaultMapStyle = 'mapbox://styles/mapbox/light-v9';
         if (document.getElementById("root").classList.contains("dark")){
             defaultMapStyle = 'mapbox://styles/mapbox/dark-v9';
@@ -86,9 +88,23 @@ class MapViewVisualization extends Visualization {
             controller: parsedData.controller || true
         });
 
-        deckgl.setProps({
-            layers: parsedData.layers || []
-        });
+        let dataPoints = parsedData.layers[0].data || []
+        let preparedDP = []
+        dataPoints.forEach(x => preparedDP.push({position: [x.longitude, x.latitude], color: x.color || [33,33,33], radius:x.radius  || 100}))
+        console.log(preparedDP);
+
+        const scatterplotLayer = new deck.ScatterplotLayer({
+            data: preparedDP,
+            getPosition: d => [d[0], d[1], 0],
+            getColor: d => d.color,
+            getRadius: d => d.radius
+        })
+
+        if (parsedData.layers[0].type.toLowerCase() === "scatterplotlayer") {
+            deckgl.setProps({
+                layers: [scatterplotLayer]
+            });
+        }
     }
 
     setSize(size) {

--- a/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/mapView.js
+++ b/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/mapView.js
@@ -68,8 +68,11 @@ class MapViewVisualization extends Visualization {
         }
 
         let defaultMapStyle = 'mapbox://styles/mapbox/light-v9';
+        let accentColor     = [1,234,146];
+        let defaultRadius   = 150;
         if (document.getElementById("root").classList.contains("dark")){
             defaultMapStyle = 'mapbox://styles/mapbox/dark-v9';
+            accentColor     = [222,162,47];
         }
 
         const deckgl = new deck.DeckGL({
@@ -79,7 +82,7 @@ class MapViewVisualization extends Visualization {
             initialViewState: {
                 longitude: parsedData.longitude || 0.0,
                 latitude: parsedData.latitude || 0.0,
-                zoom: parsedData.zoom || 9,
+                zoom: parsedData.zoom || 11,
                 pitch: parsedData.pitch || 0
             },
             controller: parsedData.controller || true
@@ -87,10 +90,10 @@ class MapViewVisualization extends Visualization {
 
         let preparedDP = []
         if (parsedData.type === "GeoPoint") {
-            preparedDP.push({position:[parsedData.longitude,parsedData.latitude], color:parsedData.color || [1,234,146], radius:parsedData.radius || 100});
+            preparedDP.push({position:[parsedData.longitude,parsedData.latitude], color:parsedData.color || accentColor, radius:parsedData.radius || defaultRadius});
         } else {
             let dataPoints = parsedData.layers[0].data || []
-            dataPoints.forEach(x => preparedDP.push({position:[x.longitude,x.latitude], color:x.color || [1,234,146], radius:x.radius || 100}));
+            dataPoints.forEach(x => preparedDP.push({position:[x.longitude,x.latitude], color:x.color || accentColor, radius:x.radius || defaultRadius}));
         }
 
         const scatterplotLayer = new deck.ScatterplotLayer({

--- a/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/mapView.js
+++ b/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/mapView.js
@@ -131,21 +131,21 @@ class MapViewVisualization extends Visualization {
             latitude  = parsedData.latitude;
             longitude = parsedData.longitude;
         } else if (Array.isArray(parsedData) && parsedData.length && parsedData[0].type === GEO_POINT) {
-            const computed    = this.prepareDataPointsHelper(parsedData,preparedDataPoints,accentColor);
-            latitude = computed.latitude;
-            longitude  = computed.longitude;
+            const computed = this.prepareDataPointsHelper(parsedData,preparedDataPoints,accentColor);
+            latitude       = computed.latitude;
+            longitude      = computed.longitude;
         } else {
             if (parsedData.type === SCATTERPLOT_LAYER && parsedData.data.length) {
-                const computed    = this.prepareDataPointsHelper(parsedData.data,preparedDataPoints,accentColor);
-                latitude = computed.latitude;
-                longitude  = computed.longitude;
+                const computed = this.prepareDataPointsHelper(parsedData.data,preparedDataPoints,accentColor);
+                latitude       = computed.latitude;
+                longitude      = computed.longitude;
             } else if (parsedData.type === GEO_MAP && parsedData.layers !== undefined) {
                 parsedData.layers.forEach(layer => {
                     if (layer.type === SCATTERPLOT_LAYER) {
-                        let dataPoints    = layer.data || [];
-                        const computed    = this.prepareDataPointsHelper(dataPoints,preparedDataPoints,accentColor);
-                        latitude = computed.latitude;
-                        longitude  = computed.longitude;
+                        let dataPoints = layer.data || [];
+                        const computed = this.prepareDataPointsHelper(dataPoints,preparedDataPoints,accentColor);
+                        latitude       = computed.latitude;
+                        longitude      = computed.longitude;
                     } else {
                         console.log("Currently unsupported deck.gl layer.")
                     }

--- a/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/mapView.js
+++ b/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/mapView.js
@@ -66,7 +66,7 @@ class MapViewVisualization extends Visualization {
         if (typeof data === "string") {
             parsedData = JSON.parse(data);
         }
-        
+
         let defaultMapStyle = 'mapbox://styles/mapbox/light-v9';
         if (document.getElementById("root").classList.contains("dark")){
             defaultMapStyle = 'mapbox://styles/mapbox/dark-v9';
@@ -87,8 +87,11 @@ class MapViewVisualization extends Visualization {
 
         let dataPoints = parsedData.layers[0].data || []
         let preparedDP = []
-        dataPoints.forEach(x => preparedDP.push({position:[x.longitude,x.latitude], color:x.color || [1,234,146], radius:x.radius || 100}))
-        console.log(preparedDP);
+        if (parsedData.type === "GeoPoint") {
+            preparedDP.push({position:[parsedData.longitude,parsedData.latitude], color:parsedData.color || [1,234,146], radius:parsedData.radius || 100});
+        } else {
+            dataPoints.forEach(x => preparedDP.push({position:[x.longitude,x.latitude], color:x.color || [1,234,146], radius:x.radius || 100}));
+        }
 
         const scatterplotLayer = new deck.ScatterplotLayer({
             data: preparedDP,
@@ -96,7 +99,7 @@ class MapViewVisualization extends Visualization {
             getRadius: d => d.radius
         })
 
-        if (parsedData.layers[0].type === "ScatterplotLayer") {
+        if (parsedData.type === "GeoPoint" || parsedData.layers[0].type === "ScatterplotLayer") {
             deckgl.setProps({
                 layers: [scatterplotLayer]
             });

--- a/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/mapView.js
+++ b/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/mapView.js
@@ -50,15 +50,15 @@ document.head.appendChild(styleHead);
  *
  * > Example creates a map with described properties with a scatter plot overlay:
  * {
- * "type": "GeoMap",
+ * "type": "Geo_Map",
  * "latitude": 37.8,
  * "longitude": -122.45,
  * "zoom": 15,
  * "controller": true,
  * "layers": [{
- *     "type": "ScatterplotLayer",
+ *     "type": "Scatterplot_Layer",
  *     "data": [{
- *         "type": "GeoPoint",
+ *         "type": "Geo_Point",
  *         "latitude": -122.45,
  *         "longitude": 37.8,
  *         "color": [255, 0, 0],

--- a/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/mapView.js
+++ b/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/mapView.js
@@ -152,10 +152,13 @@ class MapViewVisualization extends Visualization {
                 })
             }
         }
-
         return {latitude,longitude,zoom}
     }
 
+    /**
+     * Helper for prepareDataPoints, calculating also central point.
+     * @returns {{latitude: number, longitude: number}} - center.
+     */
     prepareDataPointsHelper(dataPoints,preparedDataPoints,accentColor) {
         let latitudes = [];
         let longitudes = [];


### PR DESCRIPTION
### Pull Request Description
Found one more issue : getColor was deprecated, so that's why scatterplot didn't want to work properly.
Previously GeoMaps used unsafe eval() method and was passed a JS object. Now enso types work and json strings.

Screens:
Here you can see a new scatterplot layer. notice how it doesnt define center or zoom on map, those values are computed from the points:
<img width="716" alt="Zrzut ekranu 2020-11-10 o 21 24 53" src="https://user-images.githubusercontent.com/26655166/98729575-679a4a80-239b-11eb-9dc0-2d39df2723bb.png">

It can also simply show a point on map without any problem whatsoever:
<img width="256" alt="Zrzut ekranu 2020-11-10 o 21 25 14" src="https://user-images.githubusercontent.com/26655166/98729585-6b2dd180-239b-11eb-838a-8333ebb20511.png">

And display highly customizable GeoMap:
<img width="356" alt="Zrzut ekranu 2020-11-10 o 21 25 48" src="https://user-images.githubusercontent.com/26655166/98729586-6bc66800-239b-11eb-94b6-8f36d7539bf4.png">


Test enso file:
```hs
from Base import all

type GeoPoint latitude longitude
type ScatterplotLayer data=[]
type GeoMap latitude=Nothing longitude=Nothing zoom=5 controller=True layers=[]

main =
    pt1 = GeoPoint 37.85 -122.451
    pt2 = GeoPoint 37.86 -122.452
    pt3 = GeoPoint 37.82 -122.453
    pt4 = GeoPoint 37.84 -122.454
    pt5 = GeoPoint 37.83 -122.455
    sp  = ScatterplotLayer [pt1,pt2,pt3,pt4,pt5]
    mp  = GeoMap 37.8 -122.45 9 True [sp]
```

### Important Notes
<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/main/docs/style-guide/rust.md) style guide.
- [x] All code has been tested where possible.
- [ ] All code has been profiled where possible.

