### PR TITLE
Show loading bar for the whole loading duration.

### DIFF
--- a/src/js/lib/content/src/index.html
+++ b/src/js/lib/content/src/index.html
@@ -72,6 +72,11 @@
                 border-radius: 14px;
                 box-shadow: 0 0 10px hsla(0, 0%, 0%, 0.1);
             }
+
+            #loader {
+                /* FIXME[mm]: This should be based on the theme colors. See #914.  */
+                background-color: rgb(246, 243, 241);
+            }
         </style>
         <script type="module" src="/assets/index.js" defer></script>
     </head>

--- a/src/rust/ide/src/executor.rs
+++ b/src/rust/ide/src/executor.rs
@@ -1,6 +1,7 @@
 //! Code dealing with executors, i.e. entities that are used to execute asynchronous
 //! computations, like `Future`s or `Stream`s.
 
-pub mod web;
+pub mod delay;
 pub mod global;
 pub mod test_utils;
+pub mod web;

--- a/src/rust/ide/src/executor/delay.rs
+++ b/src/rust/ide/src/executor/delay.rs
@@ -1,0 +1,84 @@
+//! Module defining `FrameDelay` - a `Future` that wraps a closure that should be called at a later
+//! time.
+
+pub use enso_prelude::*;
+
+use enso_protocol::prelude::Future;
+use ensogl_system_web::prelude::Closure;
+use ensogl_system_web::request_animation_frame;
+use futures::task::Context;
+use futures::task::Poll;
+use futures::task::Waker;
+use std::pin::Pin;
+
+
+// ========================
+// === Type Definitions ===
+// ========================
+
+type OnFrameClosure = Closure<dyn FnMut(f64)>;
+
+
+
+// ===================
+// === Frame Delay ===
+// ===================
+
+
+/// Delayed calls to a closure. The time delays is specified in number of render frames.
+#[derive(Debug)]
+pub struct FrameDelay<T>{
+    /// Counter that keeps track of the passage of frames. Needs to be shared with the JS runtime.
+    frames_left : Rc<Cell<u64>>,
+    /// Internal closure that is shared with the JS runtime and updates the `frames_left`.
+    on_frame    : Option<OnFrameClosure>,
+    /// Target callback that is called after the delay has passed.
+    target      : T,
+}
+
+impl<T> Unpin for FrameDelay<T>{}
+
+impl<T> FrameDelay<T> {
+    /// Constructor. Takes the number of render frames and the closure that should be called after
+    /// the render frames have been called.
+    pub fn new(frames:u64, target:T) -> Self {
+        let frames_left = Rc::new(Cell::new(frames));
+        let on_frame    = None;
+        FrameDelay{frames_left,target,on_frame}
+    }
+
+    /// Return a reference to the `on_frame` Closure. Creates it if it has not been created.
+    fn on_frame_action_init_if_uninit(&mut self, waker:&Waker) -> &OnFrameClosure {
+        if self.on_frame.is_none() {
+            let waker       = waker.clone();
+            let frames_left = Rc::clone(&self.frames_left);
+            let closure     = Closure::new(move |_:f64| {
+                let decreased = frames_left.get().saturating_sub(1);
+                frames_left.set(decreased);
+                waker.clone().wake();
+            });
+            self.on_frame = Some(closure);
+        }
+        // Panic Note: initialisation above cannot fail, so this will never panic.
+        self.on_frame.as_ref().expect("`on_frame` was not initialised.")
+    }
+
+    /// Set the Js callback to be called on the next frame. Needs to be called on every frame.
+    fn set_on_frame_action(&mut self, waker:&Waker) {
+        let closure  = self.on_frame_action_init_if_uninit(waker);
+        request_animation_frame(closure);
+    }
+}
+
+impl<T:Fn()> Future for FrameDelay<T> {
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        if self.frames_left.get() > 0 {
+            self.get_mut().set_on_frame_action(cx.waker());
+            return Poll::Pending
+        }
+        (self.target)();
+        Poll::Ready(())
+    }
+}

--- a/src/rust/ide/src/lib.rs
+++ b/src/rust/ide/src/lib.rs
@@ -89,14 +89,7 @@ pub mod prelude {
 pub fn entry_point_ide() {
     web::forward_panic_hook_to_console();
     web::set_stdout();
-
-    // FIXME: This code is temporary. It's used to remove the loader UI.
     ensogl_text_msdf_sys::run_once_initialized(|| {
-        web::get_element_by_id("loader").map(|t| {
-            t.parent_node().map(|p| {
-                p.remove_child(&t).unwrap()
-            })
-        }).ok();
         IdeInitializer::new().start_and_forget();
     });
 }

--- a/src/rust/ide/view/src/debug_scenes/interface.rs
+++ b/src/rust/ide/view/src/debug_scenes/interface.rs
@@ -142,6 +142,7 @@ fn init(app:&Application) {
 
     let mut was_rendered = false;
     let mut loader_hidden = false;
+    let mut frames_until_loader_hidden = 6;
     world.on_frame(move |_| {
         let _keep_alive = &navigator;
         let _keep_alive = &project_view;
@@ -149,12 +150,16 @@ fn init(app:&Application) {
         // Temporary code removing the web-loader instance.
         // To be changed in the future.
         if was_rendered && !loader_hidden {
-            web::get_element_by_id("loader").map(|t| {
-                t.parent_node().map(|p| {
-                    p.remove_child(&t).unwrap()
-                })
-            }).ok();
-            loader_hidden = true;
+            if frames_until_loader_hidden > 0 {
+                frames_until_loader_hidden -=1;
+            } else {
+                web::get_element_by_id("loader").map(|t| {
+                    t.parent_node().map(|p| {
+                        p.remove_child(&t).unwrap()
+                    })
+                }).ok();
+                loader_hidden = true;
+            }
         }
         was_rendered = true;
     }).forget();


### PR DESCRIPTION
### Pull Request Description
Avoids early removal of the loading screen before the scene is ready.

### Important notes.
Also includes the implementation of a `FrameDelay` future. 

***Known issue***: The loading screen colour is fixed and not theme based. 

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/main/docs/style-guide/rust.md) style guide.
- [x] All code has been tested where possible.
- [x] All code has been profiled where possible.

