### PR TITLE
Correclty set project name after `rename`.

### DIFF
--- a/src/rust/ide/view/graph-editor/src/component/breadcrumbs/project_name.rs
+++ b/src/rust/ide/view/graph-editor/src/component/breadcrumbs/project_name.rs
@@ -202,6 +202,7 @@ impl ProjectNameModel {
         let name = name.into();
         debug!(self.logger, "Renaming: '{name}'.");
         self.update_text_field_content(&name);
+        self.commit(name);
     }
 
     fn commit<T:Into<String>>(&self, name:T) {

--- a/src/rust/ide/view/graph-editor/src/component/breadcrumbs/project_name.rs
+++ b/src/rust/ide/view/graph-editor/src/component/breadcrumbs/project_name.rs
@@ -179,11 +179,13 @@ impl ProjectNameModel {
         self
     }
 
+    /// Revert the text field content to the last committed project name.
     fn reset_name(&self) {
         debug!(self.logger, "Resetting project name.");
         self.update_text_field_content(self.project_name.borrow().as_str());
     }
 
+    /// Update the visible content of the text field.
     fn update_text_field_content(&self, content:&str) {
         self.text_field.set_content(content);
         self.update_alignment(content);
@@ -198,6 +200,7 @@ impl ProjectNameModel {
         self.text_field.set_position(value);
     }
 
+    /// Change the text field content and commit the given name.
     fn rename(&self, name:impl Str) {
         let name = name.into();
         debug!(self.logger, "Renaming: '{name}'.");
@@ -205,6 +208,7 @@ impl ProjectNameModel {
         self.commit(name);
     }
 
+    /// Confirm the given name as the current project name.
     fn commit<T:Into<String>>(&self, name:T) {
         let name = name.into();
         debug!(self.logger, "Committing name: '{name}'.");


### PR DESCRIPTION
### Pull Request Description
When calling `rename` we only updated the visible project name, not the internally stored last committed one. 
So on pressing `esc` after startup, the initial project name was still `""` and we reverted to that one. 
This PR fixes that by adding the missing `commit` call to the `rename` method.

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/main/docs/style-guide/rust.md) style guide.
- [x] All code has been tested where possible.
- [x] All code has been profiled where possible.

