### PR TITLE
Fix initial state of Project View

### DIFF
--- a/src/rust/ide/view/src/project.rs
+++ b/src/rust/ide/view/src/project.rs
@@ -217,9 +217,8 @@ impl View {
                     }
                 })
             );
-            editing_not_aborted          <- editing_aborted.map(|b| !b);
             let editing_finished         =  graph.output.node_editing_finished.clone_ref();
-            frp.source.editing_committed <+ editing_finished.gate(&editing_not_aborted);
+            frp.source.editing_committed <+ editing_finished.gate_not(&editing_aborted);
             frp.source.editing_aborted   <+ editing_finished.gate(&editing_aborted);
             editing_aborted              <+ graph.output.node_editing_finished.constant(false);
 


### PR DESCRIPTION
### Pull Request Description
In Project View FRP network in initial state editing was neither aborted and not-aborted, what gave a strange results. For example: the first created node was not put into the module code.

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/main/docs/style-guide/rust.md) style guide.
- [x] All code has been tested where possible.
- [x] All code has been profiled where possible.

