### PR TITLE
Deactivate project name editing on node editing.

### DIFF
--- a/src/rust/ide/view/graph-editor/src/lib.rs
+++ b/src/rust/ide/view/graph-editor/src/lib.rs
@@ -1709,8 +1709,8 @@ fn new_graph_editor(app:&Application) -> GraphEditor {
     // === Commit project name edit ===
 
     frp::extend! { network
-        eval_ touch.background.selected(model.breadcrumbs.outside_press.emit(()));
-        eval_ inputs.edit_mode_on(model.breadcrumbs.outside_press.emit(()));
+        deactivate_breadcrumbs <- any3_(&touch.background.selected,&inputs.edit_mode_on,&inputs.add_node_at_cursor);
+        eval_ deactivate_breadcrumbs(model.breadcrumbs.outside_press());
     }
 
 

--- a/src/rust/ide/view/graph-editor/src/lib.rs
+++ b/src/rust/ide/view/graph-editor/src/lib.rs
@@ -1710,6 +1710,7 @@ fn new_graph_editor(app:&Application) -> GraphEditor {
 
     frp::extend! { network
         eval_ touch.background.selected(model.breadcrumbs.outside_press.emit(()));
+        eval_ inputs.edit_mode_on(model.breadcrumbs.outside_press.emit(()));
     }
 
 


### PR DESCRIPTION

### Pull Request Description
Deactivate project name editing on node editing to avoid the project name keeping focus when a node is edited.

### Important Notes
Proper fix would be to use focus management from #822, which does not exist yet.

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/main/docs/style-guide/rust.md) style guide.
- [x] All code has been tested where possible.
- [x] All code has been profiled where possible.

