### PR TITLE
Enable editing the project name only on `cmd+lmb` and `double press`.

### DIFF
--- a/build/run.js
+++ b/build/run.js
@@ -135,7 +135,7 @@ commands.build.rust = async function(argv) {
 
         console.log('Checking the resulting WASM size.')
         let stats = fss.statSync(paths.dist.wasm.mainOptGz)
-        let limit = 4.19
+        let limit = 4.20
         let size = Math.round(100 * stats.size / 1024 / 1024) / 100
         if (size > limit) {
             throw(`Output file size exceeds the limit (${size}MB > ${limit}MB).`)

--- a/src/rust/ide/view/graph-editor/src/component/breadcrumbs.rs
+++ b/src/rust/ide/view/graph-editor/src/component/breadcrumbs.rs
@@ -87,6 +87,9 @@ ensogl::define_endpoints! {
         /// Signalizes we want to cancel project name renaming, bringing back the project name before
         /// editing.
         cancel_project_name_editing (),
+        /// Signalizes we want to start editing the project name. Adds a cursor to the text edit
+        /// field at the mouse position.
+        start_project_name_editing (),
         /// Sets the project name.
         project_name                (String),
         /// Select the breadcrumb by its index.
@@ -98,6 +101,8 @@ ensogl::define_endpoints! {
         debug_pop_breadcrumb        (),
         /// Selects the breadcrumb by its index without sending signals to the controller.
         debug_select_breadcrumb     (usize),
+        /// Indicates the IDE is in text edit mode.
+        ide_text_edit_mode          (bool)
     }
     Output {
         /// Signalizes when a new breadcrumb is pushed.
@@ -113,6 +118,10 @@ ensogl::define_endpoints! {
         /// Indicates the pointer style that should be shown based on the interactions with the
         /// breadcrumb.
         pointer_style      (cursor::Style),
+        /// Indicates whether the cursor hovers over the project name.
+        project_name_hovered (bool),
+        /// Indicates whether the project name was clicked.
+        project_mouse_down (),
     }
 }
 
@@ -402,6 +411,11 @@ impl Breadcrumbs {
             eval frp.input.project_name((name) model.project_name.set_name.emit(name));
             frp.source.project_name <+ model.project_name.output.name;
 
+            eval_ frp.input.start_project_name_editing( model.project_name.start_editing.emit(()) );
+            eval frp.ide_text_edit_mode((value) model.project_name.ide_text_edit_mode.emit(value) );
+
+            frp.source.project_name_hovered <+ model.project_name.is_hovered;
+            frp.source.project_mouse_down   <+ model.project_name.mouse_down;
 
             // === GUI Update ===
 

--- a/src/rust/ide/view/graph-editor/src/lib.rs
+++ b/src/rust/ide/view/graph-editor/src/lib.rs
@@ -1824,10 +1824,20 @@ fn new_graph_editor(app:&Application) -> GraphEditor {
     // === Project Name Editing ===
     // ============================
 
+
+    // === Start project name edit ===
+    frp::extend! { network
+        edit_mode     <- bool(&inputs.edit_mode_off,&inputs.edit_mode_on);
+        eval edit_mode ((edit_mode_on) model.breadcrumbs.ide_text_edit_mode.emit(edit_mode_on));
+    }
+
+
     // === Commit project name edit ===
 
     frp::extend! { network
-        deactivate_breadcrumbs <- any3_(&touch.background.selected,&inputs.edit_mode_on,&inputs.add_node_at_cursor);
+        deactivate_breadcrumbs <- any3_(&touch.background.down,
+                                        &out.node_editing_started,
+                                        &out.node_entered);
         eval_ deactivate_breadcrumbs(model.breadcrumbs.outside_press());
     }
 


### PR DESCRIPTION
### Pull Request Description
Removes the ability to edit the project name with a single click. Instead, the project name can now be made editable by `double press` or `cmd+click`.  Also, the cursor appearance is adjusted accordingly: cmd+hover shows an I-bar. 

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/main/docs/style-guide/rust.md) style guide.
- [x] All code has automatic tests where possible.
- [x] All code has been profiled where possible.
- [x] All code has been manually tested in the IDE.
- [x] All code has been manually tested in the "debug/interface" scene.
- [x] All code has been manually tested by the PR owner against our [test scenarios](https://docs.google.com/spreadsheets/d/1RatJDM_f9_3bvYhl3Bpq2d8SyKgtVdrV1RkGxPU17c8/edit?ts=5faa7049#gid=0).
- [ ] All code has been manually tested by at least one reviewer against our [test scenarios](https://docs.google.com/spreadsheets/d/1RatJDM_f9_3bvYhl3Bpq2d8SyKgtVdrV1RkGxPU17c8/edit?ts=5faa7049#gid=0).

