### PR TITLE
Optimize Node Expression Refreshes in Gui

### DIFF
--- a/build/run.js
+++ b/build/run.js
@@ -135,7 +135,7 @@ commands.build.rust = async function(argv) {
 
         console.log('Checking the resulting WASM size.')
         let stats = fss.statSync(paths.dist.wasm.mainOptGz)
-        let limit = 4.19
+        let limit = 4.2
         let size = Math.round(100 * stats.size / 1024 / 1024) / 100
         if (size > limit) {
             throw(`Output file size exceeds the limit (${size}MB > ${limit}MB).`)

--- a/src/rust/ide/lib/span-tree/src/generate.rs
+++ b/src/rust/ide/lib/span-tree/src/generate.rs
@@ -49,10 +49,17 @@ pub trait SpanTreeGenerator<T> {
 // === String ===
 // ==============
 
-impl<T:Payload> SpanTreeGenerator<T> for String {
+impl<T:Payload> SpanTreeGenerator<T> for &str {
     fn generate_node
     (&self, kind:impl Into<node::Kind>, _:&impl Context) -> FallibleResult<Node<T>> {
         Ok(Node::<T>::new().with_kind(kind).with_size(Size::new(self.len())))
+    }
+}
+
+impl<T:Payload> SpanTreeGenerator<T> for String {
+    fn generate_node
+    (&self, kind:impl Into<node::Kind>, context:&impl Context) -> FallibleResult<Node<T>> {
+        self.as_str().generate_node(kind,context)
     }
 }
 

--- a/src/rust/ide/src/view/integration.rs
+++ b/src/rust/ide/src/view/integration.rs
@@ -580,8 +580,6 @@ impl Model {
                 })
             });
             self.set_method_pointer(id,method_pointer);
-        } else {
-            debug!(self.logger, "Failed to get `NodeId` for ID: {id:?}.");
         }
     }
 

--- a/src/rust/ide/src/view/integration.rs
+++ b/src/rust/ide/src/view/integration.rs
@@ -31,7 +31,6 @@ use ide_view::graph_editor::GraphEditor;
 use ide_view::graph_editor::SharedHashMap;
 use utils::channel::process_stream_with_handle;
 
-use span_tree::traits::SpanTreeGenerator;
 
 
 // ==============
@@ -170,7 +169,7 @@ struct Model {
     project            : model::Project,
     visualization      : controller::Visualization,
     node_views         : RefCell<BiMap<ast::Id,graph_editor::NodeId>>,
-    expression_views   : RefCell<HashMap<graph_editor::NodeId,String>>,
+    expression_views   : RefCell<HashMap<graph_editor::NodeId,graph_editor::component::node::Expression>>,
     connection_views   : RefCell<BiMap<controller::graph::Connection,graph_editor::EdgeId>>,
     code_view          : CloneRefCell<ensogl_text::Text>,
     visualizations     : SharedHashMap<graph_editor::NodeId,VisualizationId>,
@@ -538,12 +537,14 @@ impl Model {
         //  changed or not, we shall emit the updates.
         //  This should be addressed as part of https://github.com/enso-org/ide/issues/787
         let code_and_trees = graph_editor::component::node::Expression {
-            code             : expression.clone(),
+            code             : expression,
             input_span_tree  : trees.inputs,
             output_span_tree : trees.outputs.unwrap_or_else(default)
         };
-        self.view.graph().frp.input.set_node_expression.emit_event(&(id, code_and_trees));
-        self.expression_views.borrow_mut().insert(id, expression);
+        if !self.expression_views.borrow().get(&id).contains(&&code_and_trees) {
+            self.view.graph().frp.input.set_node_expression.emit_event(&(id, code_and_trees.clone()));
+            self.expression_views.borrow_mut().insert(id,code_and_trees);
+        }
 
         // Set initially available type information on ports (identifiable expression's sub-parts).
         for expression_part in node.info.expression().iter_recursive() {
@@ -808,8 +809,9 @@ impl Model {
     fn node_expression_set_in_ui
     (&self, (displayed_id,expression):&(graph_editor::NodeId,String)) -> FallibleResult {
         debug!(self.logger, "Setting node expression.");
-        let searcher = self.searcher.borrow();
-        self.expression_views.borrow_mut().insert(*displayed_id,expression.clone());
+        let searcher       = self.searcher.borrow();
+        let code_and_trees = graph_editor::component::node::Expression::new_plain(expression);
+        self.expression_views.borrow_mut().insert(*displayed_id,code_and_trees);
         if let Some(searcher) = searcher.as_ref() {
             searcher.set_input(expression.clone())?;
         }
@@ -856,15 +858,13 @@ impl Model {
     (&self, entry:&Option<ide_view::searcher::entry::Id>) -> FallibleResult {
         debug!(self.logger, "Picking suggestion.");
         if let Some(entry) = entry {
-            let graph_frp        = &self.view.graph().frp;
-            let error            = || MissingSearcherController;
-            let searcher         = self.searcher.borrow().clone().ok_or_else(error)?;
-            let error            = || GraphEditorInconsistency;
-            let edited_node      = graph_frp.output.node_being_edited.value().ok_or_else(error)?;
-            let code             = searcher.pick_completion_by_index(*entry)?;
-            let input_span_tree  = code.generate_tree(&span_tree::generate::context::Empty)?;
-            let output_span_tree = default();
-            let code_and_trees = node::Expression {code,input_span_tree,output_span_tree};
+            let graph_frp      = &self.view.graph().frp;
+            let error          = || MissingSearcherController;
+            let searcher       = self.searcher.borrow().clone().ok_or_else(error)?;
+            let error          = || GraphEditorInconsistency;
+            let edited_node    = graph_frp.output.node_being_edited.value().ok_or_else(error)?;
+            let code           = searcher.pick_completion_by_index(*entry)?;
+            let code_and_trees = node::Expression::new_plain(code);
             graph_frp.input.set_node_expression.emit_event(&(edited_node,code_and_trees));
         }
         Ok(())

--- a/src/rust/ide/view/graph-editor/src/component/node.rs
+++ b/src/rust/ide/view/graph-editor/src/component/node.rs
@@ -298,7 +298,7 @@ impl NodeModel {
     }
 
     fn init(self) -> Self {
-        self.set_expression(Expression::debug_from_str("empty"));
+        self.set_expression(Expression::new_plain("empty"));
         self
     }
 

--- a/src/rust/ide/view/graph-editor/src/component/node/expression.rs
+++ b/src/rust/ide/view/graph-editor/src/component/node/expression.rs
@@ -1,6 +1,7 @@
 use crate::prelude::*;
 
 use span_tree::SpanTree;
+use span_tree::traits::*;
 
 
 
@@ -8,7 +9,7 @@ use span_tree::SpanTree;
 // === Expression ===
 // ==================
 
-#[derive(Clone,Default)]
+#[derive(Clone,Default,Eq,PartialEq)]
 pub struct Expression {
     pub code             : String,
     pub input_span_tree  : SpanTree,
@@ -16,10 +17,10 @@ pub struct Expression {
 }
 
 impl Expression {
-    /// Constructor for debug purposes.
-    pub fn debug_from_str(s:&str) -> Self {
+    /// Constructor without output SpanTree and with single node as an input SpanTree.
+    pub fn new_plain(s:impl Into<String>) -> Self {
         let code             = s.into();
-        let input_span_tree  = default();
+        let input_span_tree  = code.generate_tree(&span_tree::generate::context::Empty).unwrap_or_default();
         let output_span_tree = default();
         Self {code,input_span_tree,output_span_tree}
     }


### PR DESCRIPTION
### Pull Request Description
The set_node_expression event in graph is not emitted if it would not change the expression nor any span-tree.

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/main/docs/style-guide/rust.md) style guide.
- [] All code has automatic tests where possible.
- [x] All code has been profiled where possible.
- [x] All code has been manually tested in the IDE.
- [] All code has been manually tested in the "debug/interface" scene. // unrelated
- [x] All code has been manually tested by the PR owner against our [test scenarios](https://docs.google.com/spreadsheets/d/1RatJDM_f9_3bvYhl3Bpq2d8SyKgtVdrV1RkGxPU17c8/edit?ts=5faa7049#gid=0).
- [ ] All code has been manually tested by at least one reviewer against our [test scenarios](https://docs.google.com/spreadsheets/d/1RatJDM_f9_3bvYhl3Bpq2d8SyKgtVdrV1RkGxPU17c8/edit?ts=5faa7049#gid=0).

