### PR TITLE
Allow double click on background to leave the current node.

### DIFF
--- a/src/rust/ensogl/lib/core/src/display/scene.rs
+++ b/src/rust/ensogl/lib/core/src/display/scene.rs
@@ -218,6 +218,20 @@ impl Target {
             panic!("Wrong internal format alpha for mouse target.")
         }
     }
+
+    pub fn is_background(&self) -> bool {
+        match self {
+            Self::Background => true,
+            _                => false,
+        }
+    }
+
+    pub fn is_symbol(&self) -> bool {
+        match self {
+            Self::Symbol {..} => true,
+            _                 => false,
+        }
+    }
 }
 
 impl Default for Target {


### PR DESCRIPTION
### Pull Request Description
Enables double clicks on the background in the graph editor to emit a `node_exited` event. 
Also restrict double click to enter the hovered nodes, not the selected ones, this addresses issue  #959.

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/main/docs/style-guide/rust.md) style guide.
- [x] All code has automatic tests where possible.
- [x] All code has been profiled where possible.
- [x] All code has been manually tested in the IDE.
- [ ] All code has been manually tested in the "debug/interface" scene. 
    - Can't be tested without language server integration.
- [x] All code has been manually tested by the PR owner against our [test scenarios](https://docs.google.com/spreadsheets/d/1RatJDM_f9_3bvYhl3Bpq2d8SyKgtVdrV1RkGxPU17c8/edit?ts=5faa7049#gid=0).
- [x] All code has been manually tested by at least one reviewer against our [test scenarios](https://docs.google.com/spreadsheets/d/1RatJDM_f9_3bvYhl3Bpq2d8SyKgtVdrV1RkGxPU17c8/edit?ts=5faa7049#gid=0).

