### PR TITLE
Apply selected node as "this" in all cases.

### DIFF
--- a/src/rust/ide/src/controller/searcher/suggestion.rs
+++ b/src/rust/ide/src/controller/searcher/suggestion.rs
@@ -23,7 +23,11 @@ impl Suggestion {
     /// The suggestion caption (suggested function name, or action name, etc.).
     pub fn caption(&self) -> String {
         match self {
-            Self::Completion(completion) => completion.code_to_insert(None)
+            Self::Completion(completion) => if let Some(self_type) = completion.self_type.as_ref() {
+                format!("{}.{}",self_type,completion.name)
+            } else {
+                completion.name.clone()
+            }
         }
     }
 }

--- a/src/rust/ide/src/controller/searcher/suggestion.rs
+++ b/src/rust/ide/src/controller/searcher/suggestion.rs
@@ -23,7 +23,7 @@ impl Suggestion {
     /// The suggestion caption (suggested function name, or action name, etc.).
     pub fn caption(&self) -> String {
         match self {
-            Self::Completion(completion) => completion.code_to_insert(None,None)
+            Self::Completion(completion) => completion.code_to_insert(None)
         }
     }
 }

--- a/src/rust/ide/src/model/suggestion_database.rs
+++ b/src/rust/ide/src/model/suggestion_database.rs
@@ -127,6 +127,12 @@ impl Entry {
         }
     }
 
+    /// Returns the code which should be inserted to Searcher input when suggestion is picked,
+    /// omitting module name.
+    pub fn code_to_insert_skip_module(&self) -> String {
+        self.name.clone()
+    }
+
     /// Return the Method Id of suggested method.
     ///
     /// Returns none, if this is not suggestion for a method.

--- a/src/rust/ide/src/model/suggestion_database.rs
+++ b/src/rust/ide/src/model/suggestion_database.rs
@@ -116,15 +116,12 @@ impl Entry {
     }
 
     /// Returns the code which should be inserted to Searcher input when suggestion is picked.
-    pub fn code_to_insert
-    (&self, this_var:Option<&str>, current_module:Option<&QualifiedName>) -> String {
+    pub fn code_to_insert(&self, current_module:Option<&QualifiedName>) -> String {
         let module_name = self.module.name();
         if self.has_self_type(&module_name) {
             let module_var = if current_module.contains(&&self.module) {keywords::HERE}
                 else {module_name};
-            format!("{}.{}",this_var.unwrap_or(module_var),self.name)
-        } else if let Some(this_var) = this_var {
-            format!("{}.{}",this_var,self.name)
+            format!("{}.{}",module_var,self.name)
         } else {
             self.name.clone()
         }
@@ -582,41 +579,20 @@ mod test {
             ..method_entry.clone()
         };
 
-        let this_var = None;
         let current_module = None;
-        assert_eq!(atom_entry.code_to_insert(this_var,current_module)         , "Atom");
-        assert_eq!(method_entry.code_to_insert(this_var,current_module)       , "method");
-        assert_eq!(module_method_entry.code_to_insert(this_var,current_module), "Main.moduleMethod");
+        assert_eq!(atom_entry.code_to_insert(current_module)         , "Atom");
+        assert_eq!(method_entry.code_to_insert(current_module)       , "method");
+        assert_eq!(module_method_entry.code_to_insert(current_module), "Main.moduleMethod");
 
-        let this_var = Some("var");
-        let current_module = None;
-        assert_eq!(atom_entry.code_to_insert(this_var,current_module)         , "var.Atom");
-        assert_eq!(method_entry.code_to_insert(this_var,current_module)       , "var.method");
-        assert_eq!(module_method_entry.code_to_insert(this_var,current_module), "var.moduleMethod");
-
-        let this_var = None;
         let current_module = Some(&module);
-        assert_eq!(atom_entry.code_to_insert(this_var,current_module)         , "Atom");
-        assert_eq!(method_entry.code_to_insert(this_var,current_module)       , "method");
-        assert_eq!(module_method_entry.code_to_insert(this_var,current_module), "here.moduleMethod");
+        assert_eq!(atom_entry.code_to_insert(current_module)         , "Atom");
+        assert_eq!(method_entry.code_to_insert(current_module)       , "method");
+        assert_eq!(module_method_entry.code_to_insert(current_module), "here.moduleMethod");
 
-        let this_var = Some("var");
-        let current_module = Some(&module);
-        assert_eq!(atom_entry.code_to_insert(this_var,current_module)         , "var.Atom");
-        assert_eq!(method_entry.code_to_insert(this_var,current_module)       , "var.method");
-        assert_eq!(module_method_entry.code_to_insert(this_var,current_module), "var.moduleMethod");
-
-        let this_var = None;
         let current_module = Some(&another_module);
-        assert_eq!(atom_entry.code_to_insert(this_var,current_module)         , "Atom");
-        assert_eq!(method_entry.code_to_insert(this_var,current_module)       , "method");
-        assert_eq!(module_method_entry.code_to_insert(this_var,current_module), "Main.moduleMethod");
-
-        let this_var = Some("var");
-        let current_module = Some(&another_module);
-        assert_eq!(atom_entry.code_to_insert(this_var,current_module)         , "var.Atom");
-        assert_eq!(method_entry.code_to_insert(this_var,current_module)       , "var.method");
-        assert_eq!(module_method_entry.code_to_insert(this_var,current_module), "var.moduleMethod");
+        assert_eq!(atom_entry.code_to_insert(current_module)         , "Atom");
+        assert_eq!(method_entry.code_to_insert(current_module)       , "method");
+        assert_eq!(module_method_entry.code_to_insert(current_module), "Main.moduleMethod");
     }
 
     #[test]

--- a/src/rust/ide/src/view/integration.rs
+++ b/src/rust/ide/src/view/integration.rs
@@ -1133,7 +1133,7 @@ impl DataProviderForView {
             EntryKind::Local    => "Local variable",
             EntryKind::Method   => "Method",
         };
-        format!("{} `{}`\n\nNo documentation available", title,suggestion.code_to_insert(None,None))
+        format!("{} `{}`\n\nNo documentation available", title,suggestion.code_to_insert(None))
     }
 }
 


### PR DESCRIPTION
### Pull Request Description
Before the selected node, which ought to be passed as "this" argument for the next added node, was added when user picked function suggestion, immediately to the searcher input.

This PR changes that behavior: now the function name only is put into input. When new node is commited, then the this argument will be applied - even if user will not have picked any suggestion.

### Important Notes
<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/main/docs/style-guide/rust.md) style guide.
- [x] All code has automatic tests where possible.
- [x] All code has been profiled where possible.
- [x] All code has been manually tested in the IDE.
- [x] All code has been manually tested in the "debug/interface" scene.
- [x] All code has been manually tested by the PR owner against our [test scenarios](https://docs.google.com/spreadsheets/d/1RatJDM_f9_3bvYhl3Bpq2d8SyKgtVdrV1RkGxPU17c8/edit?ts=5faa7049#gid=0).
- [x] All code has been manually tested by at least one reviewer against our [test scenarios](https://docs.google.com/spreadsheets/d/1RatJDM_f9_3bvYhl3Bpq2d8SyKgtVdrV1RkGxPU17c8/edit?ts=5faa7049#gid=0).

