### PR TITLE
Fix missing connection in some cases.

### DIFF
--- a/build/run.js
+++ b/build/run.js
@@ -135,7 +135,7 @@ commands.build.rust = async function(argv) {
 
         console.log('Checking the resulting WASM size.')
         let stats = fss.statSync(paths.dist.wasm.mainOptGz)
-        let limit = 4.20
+        let limit = 4.21
         let size = Math.round(100 * stats.size / 1024 / 1024) / 100
         if (size > limit) {
             throw(`Output file size exceeds the limit (${size}MB > ${limit}MB).`)

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -34,7 +34,7 @@ members = [
 ]
 
 [profile.dev]
-opt-level = 2
+opt-level = 0
 lto       = false
 debug     = true
 

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -34,7 +34,7 @@ members = [
 ]
 
 [profile.dev]
-opt-level = 0
+opt-level = 2
 lto       = false
 debug     = true
 

--- a/src/rust/ide/lib/span-tree/src/generate.rs
+++ b/src/rust/ide/lib/span-tree/src/generate.rs
@@ -983,7 +983,6 @@ mod test {
         };
         let ctx      = MockContext::new_single(ast.id.unwrap(),invocation_info);
         let mut tree = SpanTree::new(&ast,&ctx).unwrap() : SpanTree;
-        // assert!(false, "{:?}", tree);
         match tree.root_ref().leaf_iter().collect_vec().as_slice() {
             [_,_this,_,_,_func,_,arg1,arg2] => {
                 assert_eq!(arg1.argument_info().as_ref(),Some(&param1));

--- a/src/rust/ide/lib/span-tree/src/generate.rs
+++ b/src/rust/ide/lib/span-tree/src/generate.rs
@@ -973,6 +973,41 @@ mod test {
         clear_expression_ids(&mut tree.root);
         clear_parameter_infos(&mut tree.root);
         assert_eq!(tree,expected);
+
+
+        // === Partial application chain - this argument ===
+
+        let ast = parser.parse_line("here.foo").unwrap();
+        let invocation_info = CalledMethodInfo {
+            parameters : vec![this_param.clone(), param1.clone(), param2.clone()]
+        };
+        let ctx      = MockContext::new_single(ast.id.unwrap(),invocation_info);
+        let mut tree = SpanTree::new(&ast,&ctx).unwrap() : SpanTree;
+        // assert!(false, "{:?}", tree);
+        match tree.root_ref().leaf_iter().collect_vec().as_slice() {
+            [_,_this,_,_,_func,_,arg1,arg2] => {
+                assert_eq!(arg1.argument_info().as_ref(),Some(&param1));
+                assert_eq!(arg2.argument_info().as_ref(),Some(&param2));
+            },
+            sth_else => panic!("There should be 8 leaves, found: {}",sth_else.len()),
+        }
+        let expected = TreeBuilder::new(8)
+            .add_child(0,8,node::Kind::Chained,Crumbs::default())
+                .add_child(0,8,node::Kind::Operation,Crumbs::default())
+                    .add_empty_child(0,BeforeTarget)
+                    .add_leaf(0,4,node::Kind::this(),InfixCrumb::LeftOperand)
+                    .add_empty_child(4,AfterTarget)
+                    .add_leaf(4,1,node::Kind::Operation,InfixCrumb::Operator)
+                    .add_leaf(5,3,node::Kind::argument(),InfixCrumb::RightOperand)
+                    .add_empty_child(8,Append)
+                    .done()
+                .add_empty_child(8,ExpectedArgument(0))
+                .done()
+            .add_empty_child(8,ExpectedArgument(1))
+            .build();
+        clear_expression_ids(&mut tree.root);
+        clear_parameter_infos(&mut tree.root);
+        assert_eq!(tree,expected);
     }
 
     fn segment_body_crumbs(index:usize, pattern_crumb:&Vec<PatternMatchCrumb>) -> ast::crumbs::MatchCrumb {

--- a/src/rust/ide/lib/span-tree/src/node.rs
+++ b/src/rust/ide/lib/span-tree/src/node.rs
@@ -469,6 +469,7 @@ impl<'a,T:Payload> Ref<'a,T> {
     /// structure will have non-empty `ast_crumbs` field.
     pub fn get_descendant_by_ast_crumbs<'b>
     (self, ast_crumbs:&'b [ast::Crumb]) -> Option<NodeFoundByAstCrumbs<'a,'b,T>> {
+        println!("Getting descendant: {:?} AST {:?}", self.crumbs, ast_crumbs);
         if self.node.children.is_empty() || ast_crumbs.is_empty() {
             let node                 = self;
             let remaining_ast_crumbs = ast_crumbs;
@@ -479,7 +480,8 @@ impl<'a,T:Payload> Ref<'a,T> {
             // therefore have different meaning!
             let next = children.find_position(|ch| {
                 !ch.ast_crumbs.is_empty() && ast_crumbs.starts_with(&ch.ast_crumbs)
-            });
+            }).or_else(|| children.find_position(|ch| ch.ast_crumbs.is_empty() && !ch.kind.is_insertion_point()));
+            println!("Trying {:?}", next.as_ref().map(|(id,_)| id));
             next.and_then(|(id,child)| {
                 let ast_subcrumbs = &ast_crumbs[child.ast_crumbs.len()..];
                 self.child(id).unwrap().get_descendant_by_ast_crumbs(ast_subcrumbs)

--- a/src/rust/ide/lib/span-tree/src/node.rs
+++ b/src/rust/ide/lib/span-tree/src/node.rs
@@ -469,19 +469,18 @@ impl<'a,T:Payload> Ref<'a,T> {
     /// structure will have non-empty `ast_crumbs` field.
     pub fn get_descendant_by_ast_crumbs<'b>
     (self, ast_crumbs:&'b [ast::Crumb]) -> Option<NodeFoundByAstCrumbs<'a,'b,T>> {
-        println!("Getting descendant: {:?} AST {:?}", self.crumbs, ast_crumbs);
         if self.node.children.is_empty() || ast_crumbs.is_empty() {
             let node                 = self;
             let remaining_ast_crumbs = ast_crumbs;
             Some(NodeFoundByAstCrumbs{node, ast_crumbs: remaining_ast_crumbs })
         } else {
-            let mut children = self.node.children.iter();
-            // Please be advised, that the `ch.ast_crumhs` is not a field of Ref, but Child, and
+            // Please be advised, that the `ch.ast_crumbs` is not a field of Ref, but Child, and
             // therefore have different meaning!
-            let next = children.find_position(|ch| {
+            let next = self.node.children.iter().find_position(|ch| {
                 !ch.ast_crumbs.is_empty() && ast_crumbs.starts_with(&ch.ast_crumbs)
-            }).or_else(|| children.find_position(|ch| ch.ast_crumbs.is_empty() && !ch.kind.is_insertion_point()));
-            println!("Trying {:?}", next.as_ref().map(|(id,_)| id));
+            }).or_else(|| self.node.children.iter().find_position(|ch| {
+                ch.ast_crumbs.is_empty() && !ch.kind.is_insertion_point()
+            }));
             next.and_then(|(id,child)| {
                 let ast_subcrumbs = &ast_crumbs[child.ast_crumbs.len()..];
                 self.child(id).unwrap().get_descendant_by_ast_crumbs(ast_subcrumbs)
@@ -679,11 +678,12 @@ impl<'a,T:Payload> RefMut<'a,T> {
 mod test {
     use crate::builder::Builder;
     use crate::builder::TreeBuilder;
+    use crate::Crumbs;
     use crate::node;
+    use crate::node::InsertionPointType;
     use crate::SpanTree;
 
     use ast::crumbs;
-    use crate::node::InsertionPointType;
 
     #[test]
     fn node_lookup() {
@@ -771,6 +771,32 @@ mod test {
             let result = root.clone().get_descendant_by_ast_crumbs(&crumbs).unwrap();
             assert_eq!(result.node.crumbs.as_slice(), *expected_crumbs);
             assert_eq!(result.ast_crumbs, expected_remaining_ast_crumbs.as_slice());
+        }
+    }
+
+    #[test]
+    fn node_lookup_by_ast_crumbs_expected_arguments_case() {
+        use ast::crumbs::InfixCrumb::*;
+
+        // An example with single call and expected arguments.
+        // See also `generate::test::generating_span_tree_for_unfinished_call`
+        let tree : SpanTree = TreeBuilder::new(8)
+            .add_child(0,8,node::Kind::Chained,ast::crumbs::Crumbs::default())
+                .add_child(0,8,node::Kind::Operation,ast::crumbs::Crumbs::default())
+                    .add_leaf(0,4,node::Kind::this(),LeftOperand)
+                    .add_leaf(4,1,node::Kind::Operation,Operator)
+                    .add_leaf(5,3,node::Kind::argument(),RightOperand)
+                    .done()
+                .add_empty_child(8,InsertionPointType::ExpectedArgument(0))
+                .done()
+            .add_empty_child(8,InsertionPointType::ExpectedArgument(1))
+            .build();
+
+        let cases = &[(crumbs!(LeftOperand),vec![0,0,0]), (crumbs!(RightOperand),vec![0,0,2])];
+
+        for (ast_crumbs,expected_crumbs) in cases {
+            let result = tree.root_ref().get_descendant_by_ast_crumbs(ast_crumbs).unwrap();
+            assert_eq!(result.node.crumbs,Crumbs::new(expected_crumbs.clone()));
         }
     }
 }

--- a/src/rust/ide/lib/span-tree/src/node.rs
+++ b/src/rust/ide/lib/span-tree/src/node.rs
@@ -479,11 +479,11 @@ impl<'a,T:Payload> Ref<'a,T> {
             let next = self.node.children.iter().find_position(|ch| {
                 !ch.ast_crumbs.is_empty() && ast_crumbs.starts_with(&ch.ast_crumbs)
             }).or_else(|| {
-                // We do the second round to cover case of "prefix-like" nodes with
-                // `InsertionPoint(ExpectedArgument(_))`. See also docs for
+                // We try to find appriopriate node second time, this time expecting case of
+                // "prefix-like" nodes with `InsertionPoint(ExpectedArgument(_))`. See also docs for
                 // `generate::generate_expected_argument`.
-                // TODO[ao]: This is kinda heuristic. Should be reconsidered in
-                //  https://github.com/enso-org/ide/issues/787
+                // TODO[ao]: As implementation of SpanTree will extend there may be some day more
+                //  cases. Should be reconsidered in https://github.com/enso-org/ide/issues/787
                 self.node.children.iter().find_position(|ch| {
                     ch.ast_crumbs.is_empty() && !ch.kind.is_insertion_point()
                 })

--- a/src/rust/ide/src/controller/graph.rs
+++ b/src/rust/ide/src/controller/graph.rs
@@ -237,8 +237,11 @@ impl Connections {
     /// Converts Endpoint from double representation to the span tree crumbs.
     pub fn convert_endpoint
     (&self, endpoint:&double_representation::connection::Endpoint) -> Option<Endpoint> {
+        println!("Getting node");
         let tree           = self.trees.get(&endpoint.node)?;
+        println!("Getting SpanTree node");
         let span_tree_node = tree.get_span_tree_node(&endpoint.crumbs)?;
+        println!("Done!");
         Some(Endpoint{
             node       : endpoint.node,
             port       : span_tree_node.node.crumbs,
@@ -249,9 +252,13 @@ impl Connections {
     /// Converts Connection from double representation to the span tree crumbs.
     pub fn convert_connection
     (&self, connection:&double_representation::connection::Connection) -> Option<Connection> {
+        println!("Converting source");
+        let source = self.convert_endpoint(&connection.source)?;
+        println!("Converting destination");
+        let destination = self.convert_endpoint(&connection.destination)?;
         Some(Connection {
-            source      : self.convert_endpoint(&connection.source)?,
-            destination : self.convert_endpoint(&connection.destination)?,
+            source      ,
+            destination ,
         })
     }
 }

--- a/src/rust/ide/src/controller/graph.rs
+++ b/src/rust/ide/src/controller/graph.rs
@@ -237,11 +237,8 @@ impl Connections {
     /// Converts Endpoint from double representation to the span tree crumbs.
     pub fn convert_endpoint
     (&self, endpoint:&double_representation::connection::Endpoint) -> Option<Endpoint> {
-        println!("Getting node");
         let tree           = self.trees.get(&endpoint.node)?;
-        println!("Getting SpanTree node");
         let span_tree_node = tree.get_span_tree_node(&endpoint.crumbs)?;
-        println!("Done!");
         Some(Endpoint{
             node       : endpoint.node,
             port       : span_tree_node.node.crumbs,
@@ -252,9 +249,7 @@ impl Connections {
     /// Converts Connection from double representation to the span tree crumbs.
     pub fn convert_connection
     (&self, connection:&double_representation::connection::Connection) -> Option<Connection> {
-        println!("Converting source");
         let source = self.convert_endpoint(&connection.source)?;
-        println!("Converting destination");
         let destination = self.convert_endpoint(&connection.destination)?;
         Some(Connection {
             source      ,
@@ -1358,7 +1353,6 @@ main =
 
                 test.data.code = main;
                 test.run(|graph| async move {
-                    println!("The nodes: {:?}", graph.nodes());
                     let (node0,node1) = graph.nodes().unwrap().expect_tuple();
                     let source        = Endpoint::new(node0.info.id(),src_port.to_vec());
                     let destination   = Endpoint::new(node1.info.id(),dst_port.to_vec());


### PR DESCRIPTION
### Pull Request Description
Introducing "labeled ports" and insertion points for expected arguments changes some Span-tree assertions we have in mind when implementing "finding by AST crumbs". This caused graph controller miss some connections in connection list - those were treated as "unconvertable" to span-tree crumbs.

### Important Notes
Applied hotfix, and left TODO to consider how to do it better.

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/main/docs/style-guide/rust.md) style guide.
- [x] All code has automatic tests where possible.
- [x] All code has been profiled where possible.
- [x] All code has been manually tested in the IDE.
- [x] All code has been manually tested in the "debug/interface" scene.
- [x] All code has been manually tested by the PR owner against our [test scenarios](https://docs.google.com/spreadsheets/d/1RatJDM_f9_3bvYhl3Bpq2d8SyKgtVdrV1RkGxPU17c8/edit?ts=5faa7049#gid=0).
- [ ] All code has been manually tested by at least one reviewer against our [test scenarios](https://docs.google.com/spreadsheets/d/1RatJDM_f9_3bvYhl3Bpq2d8SyKgtVdrV1RkGxPU17c8/edit?ts=5faa7049#gid=0).

