### PR TITLE
Only prevent default zooming when holding ctrl key.

### DIFF
--- a/build/run.js
+++ b/build/run.js
@@ -136,7 +136,7 @@ commands.build.rust = async function(argv) {
 
         console.log('Checking the resulting WASM size.')
         let stats = fss.statSync(paths.dist.wasm.mainOptGz)
-        let limit = 4.23
+        let limit = 4.24
         let size = Math.round(100 * stats.size / 1024 / 1024) / 100
         if (size > limit) {
             throw(`Output file size exceeds the limit (${size}MB > ${limit}MB).`)

--- a/src/rust/ide/view/graph-editor/src/lib.rs
+++ b/src/rust/ide/view/graph-editor/src/lib.rs
@@ -1842,8 +1842,8 @@ fn new_graph_editor(app:&Application) -> GraphEditor {
         no_vis_selected   <- out.some_visualisation_selected.on_false();
         some_vis_selected <- out.some_visualisation_selected.on_true();
 
-        set_navigator_true  <- inputs.set_navigator_disabled.on_true();
-        set_navigator_false <- inputs.set_navigator_disabled.on_false();
+        set_navigator_false  <- inputs.set_navigator_disabled.on_true();
+        set_navigator_true   <- inputs.set_navigator_disabled.on_false();
 
         disable_navigator <- any_(&set_navigator_false,&some_vis_selected);
         enable_navigator  <- any_(&set_navigator_true,&no_vis_selected);

--- a/src/rust/ide/view/src/project.rs
+++ b/src/rust/ide/view/src/project.rs
@@ -208,6 +208,10 @@ impl View {
                 }
             });
 
+            // === Searcher Selection ===
+
+            eval searcher.is_selected ((is_selected) graph.set_navigator_disabled(is_selected));
+
 
             // === Editing ===
 

--- a/src/rust/ide/view/src/searcher.rs
+++ b/src/rust/ide/view/src/searcher.rs
@@ -145,6 +145,7 @@ ensogl::define_endpoints! {
         editing_committed (),
         size              (Vector2<f32>),
         is_visible        (bool),
+        is_selected       (bool),
     }
 }
 
@@ -198,6 +199,7 @@ impl View {
             source.selected_entry <+ model.list.selected_entry;
             source.size           <+ height.value.map(|h| Vector2(SEARCHER_WIDTH,*h));
             source.is_visible     <+ model.list.size.map(|size| size.x*size.y > std::f32::EPSILON);
+            source.is_selected    <+ model.documentation.frp.is_selected.map(|&value|value);
 
             eval height.value ((h)  model.set_height(*h));
             eval frp.show     ((()) height.set_target_value(SEARCHER_HEIGHT));


### PR DESCRIPTION
### Pull Request Description
This changes the event handling behaviour when using the mouse wheel. Right now we prevent all default events, but this prevents also some [html components from receiving events](https://github.com/enso-org/ide/issues/939). Allowing default events while zooming with CTRL key, will lead to bad behaviour: the browser will do its website zooming and our UI will also zoom. We want to avoid the website zooming, but we do want to allow panning events to be received by scrollable html components.
To achieve this, this PR allows default events when a mouse wheel event is a pan event, but keeps it deactivated when there is a zoom event on CTRL + mouse wheel. 

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/main/docs/style-guide/rust.md) style guide.
- [x] All code has automatic tests where possible.
- [x] All code has been profiled where possible.
- [x] All code has been manually tested in the IDE.
- [x] ~All code has been manually tested in the "debug/interface" scene.~ - Can't seem to see any new issues with zooming, but can't check the table visualization for working scrolling because language server is required to see the visualisation.
- [x] All code has been manually tested by the PR owner against our [test scenarios](https://docs.google.com/spreadsheets/d/1RatJDM_f9_3bvYhl3Bpq2d8SyKgtVdrV1RkGxPU17c8/edit?ts=5faa7049#gid=0).
- [ ] All code has been manually tested by at least one reviewer against our [test scenarios](https://docs.google.com/spreadsheets/d/1RatJDM_f9_3bvYhl3Bpq2d8SyKgtVdrV1RkGxPU17c8/edit?ts=5faa7049#gid=0).

