### PR TITLE
Quicktake: Disable demo visualization, refactor names, remove '(JS)' from label.

### DIFF
--- a/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script.rs
+++ b/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script.rs
@@ -11,9 +11,9 @@ use crate::component::visualization;
 // JavaScript builtin visualizations //
 ///////////////////////////////////////
 
-/// Return a `JavaScript` Table view visualization.
-pub fn table_view_visualization() -> visualization::java_script::FallibleDefinition {
-    let source = include_str!("java_script/tableView.js");
+/// Return a `JavaScript` Table visualization.
+pub fn table_visualization() -> visualization::java_script::FallibleDefinition {
+    let source = include_str!("java_script/table.js");
 
     visualization::java_script::Definition::new(data::builtin_library(),source)
 }
@@ -37,7 +37,7 @@ pub fn histogram_visualization() -> visualization::java_script::FallibleDefiniti
 }
 
 /// Return a `JavaScript` Map visualization.
-pub fn map_view_visualization() -> visualization::java_script::FallibleDefinition {
+pub fn geo_map_visualization() -> visualization::java_script::FallibleDefinition {
     let loading_scripts = include_str!("java_script/loading.js");
     let source          = include_str!("java_script/geoMap.js");
     let source          = format!("{}{}",loading_scripts,source);
@@ -45,7 +45,7 @@ pub fn map_view_visualization() -> visualization::java_script::FallibleDefinitio
     visualization::java_script::Definition::new(data::builtin_library(),source)
 }
 
-/// Return a `JavaScript` Bubble visualization.
+/// Return a `JavaScript` Bubble visualization. This should not be used as it is a demo visualization.
 pub fn bubble_visualization() -> visualization::java_script::FallibleDefinition {
     let source = include_str!("java_script/bubbleVisualization.js");
 

--- a/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/scatterPlot.js
+++ b/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/scatterPlot.js
@@ -41,7 +41,7 @@ const visilbe_points = 'visible'
  */
 class ScatterPlot extends Visualization {
     static inputType = 'Any'
-    static label = 'Scatter Plot (JS)'
+    static label = 'Scatter Plot'
 
     /**
      * Presents a scatterplot visualization after receiving `data`.

--- a/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/table.js
+++ b/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/table.js
@@ -1,5 +1,6 @@
-class TableViewVisualization extends Visualization {
+class TableVisualization extends Visualization {
     static inputType = 'Any'
+    static label = 'Table'
 
     onDataReceived(data) {
         function tableOf(content, level) {
@@ -274,4 +275,4 @@ class TableViewVisualization extends Visualization {
     }
 }
 
-return TableViewVisualization
+return TableVisualization

--- a/src/rust/ide/view/graph-editor/src/component/visualization/registry.rs
+++ b/src/rust/ide/view/graph-editor/src/component/visualization/registry.rs
@@ -37,7 +37,6 @@ impl Registry {
     /// Return a `Registry` pre-populated with default visualizations.
     pub fn with_default_visualizations() -> Self {
         let registry = Self::new();
-        registry.add(builtin::visualization::native::BubbleChart::definition());
         registry.add(builtin::visualization::native::RawText::definition());
         registry.try_add_java_script(builtin::visualization::java_script::scatter_plot_visualization());
         registry.try_add_java_script(builtin::visualization::java_script::histogram_visualization());

--- a/src/rust/ide/view/graph-editor/src/component/visualization/registry.rs
+++ b/src/rust/ide/view/graph-editor/src/component/visualization/registry.rs
@@ -39,11 +39,10 @@ impl Registry {
         let registry = Self::new();
         registry.add(builtin::visualization::native::BubbleChart::definition());
         registry.add(builtin::visualization::native::RawText::definition());
-        registry.try_add_java_script(builtin::visualization::java_script::bubble_visualization());
         registry.try_add_java_script(builtin::visualization::java_script::scatter_plot_visualization());
         registry.try_add_java_script(builtin::visualization::java_script::histogram_visualization());
-        registry.try_add_java_script(builtin::visualization::java_script::table_view_visualization());
-        registry.try_add_java_script(builtin::visualization::java_script::map_view_visualization());
+        registry.try_add_java_script(builtin::visualization::java_script::table_visualization());
+        registry.try_add_java_script(builtin::visualization::java_script::geo_map_visualization());
         registry
     }
 


### PR DESCRIPTION
### Pull Request Description

1. Disables demo bubble visualization
2. TableView -> Table
3. replaced mapView to GeoMap, consistency(!)
4. Removed `(JS)` from Scatterplot label

### Important Notes
<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/main/docs/style-guide/rust.md) style guide.
- [x] All code has automatic tests where possible.
- [x] All code has been profiled where possible.
- [x] All code has been manually tested in the IDE.
- [x] All code has been manually tested in the "debug/interface" scene.
- [x] All code has been manually tested by the PR owner against our [test scenarios](https://docs.google.com/spreadsheets/d/1RatJDM_f9_3bvYhl3Bpq2d8SyKgtVdrV1RkGxPU17c8/edit?ts=5faa7049#gid=0).
- [ ] All code has been manually tested by at least one reviewer against our [test scenarios](https://docs.google.com/spreadsheets/d/1RatJDM_f9_3bvYhl3Bpq2d8SyKgtVdrV1RkGxPU17c8/edit?ts=5faa7049#gid=0).

