### PR TITLE
This Simple Trick Will Enable Coloring of Your Ports!

### DIFF
--- a/src/rust/ide/src/view/integration.rs
+++ b/src/rust/ide/src/view/integration.rs
@@ -161,18 +161,19 @@ impl Integration {
 
 #[derive(Debug)]
 struct Model {
-    logger             : Logger,
-    view               : ide_view::project::View,
-    graph              : controller::ExecutedGraph,
-    text               : controller::Text,
-    searcher           : RefCell<Option<controller::Searcher>>,
-    project            : model::Project,
-    visualization      : controller::Visualization,
-    node_views         : RefCell<BiMap<ast::Id,graph_editor::NodeId>>,
-    expression_views   : RefCell<HashMap<graph_editor::NodeId,graph_editor::component::node::Expression>>,
-    connection_views   : RefCell<BiMap<controller::graph::Connection,graph_editor::EdgeId>>,
-    code_view          : CloneRefCell<ensogl_text::Text>,
-    visualizations     : SharedHashMap<graph_editor::NodeId,VisualizationId>,
+    logger                  : Logger,
+    view                    : ide_view::project::View,
+    graph                   : controller::ExecutedGraph,
+    text                    : controller::Text,
+    searcher                : RefCell<Option<controller::Searcher>>,
+    project                 : model::Project,
+    visualization           : controller::Visualization,
+    node_views              : RefCell<BiMap<ast::Id,graph_editor::NodeId>>,
+    node_view_by_expression : RefCell<HashMap<ast::Id,graph_editor::NodeId>>,
+    expression_views        : RefCell<HashMap<graph_editor::NodeId,graph_editor::component::node::Expression>>,
+    connection_views        : RefCell<BiMap<controller::graph::Connection,graph_editor::EdgeId>>,
+    code_view               : CloneRefCell<ensogl_text::Text>,
+    visualizations          : SharedHashMap<graph_editor::NodeId,VisualizationId>,
 }
 
 
@@ -354,6 +355,7 @@ impl Model {
     , visualization : controller::Visualization
     , project       : model::Project) -> Self {
         let node_views       = default();
+        let node_view_by_expression = default();
         let connection_views = default();
         let expression_views = default();
         let code_view        = default();
@@ -361,7 +363,7 @@ impl Model {
         let searcher         = default();
         let this             = Model
             {view,graph,text,searcher,node_views,expression_views,connection_views,code_view,logger
-            ,visualization,visualizations,project};
+            ,visualization,visualizations,project,node_view_by_expression};
 
         this.init_project_name();
         this.init_visualizations();
@@ -528,19 +530,18 @@ impl Model {
         if let Some(position) = position {
             self.view.graph().frp.input.set_node_position.emit_event(&(id, position.vector));
         }
-        let expression = node.info.expression().repr();
-
-        // TODO [MWU]
-        //  Currently we cannot limit updates, as each invalidation can affect span tree generation
-        //  context and as such may require updating span trees. So no matter whether expression
-        //  changed or not, we shall emit the updates.
-        //  This should be addressed as part of https://github.com/enso-org/ide/issues/787
+        let expression     = node.info.expression().repr();
         let code_and_trees = graph_editor::component::node::Expression {
             code             : expression,
             input_span_tree  : trees.inputs,
             output_span_tree : trees.outputs.unwrap_or_else(default)
         };
         if !self.expression_views.borrow().get(&id).contains(&&code_and_trees) {
+            for sub_expression in node.info.ast().iter_recursive() {
+                if let Some(expr_id) = sub_expression.id {
+                    self.node_view_by_expression.borrow_mut().insert(expr_id,id);
+                }
+            }
             self.view.graph().frp.input.set_node_expression.emit_event(&(id, code_and_trees.clone()));
             self.expression_views.borrow_mut().insert(id,code_and_trees);
         }
@@ -570,7 +571,7 @@ impl Model {
         let info     = self.lookup_computed_info(&id);
         let info     = info.as_ref();
         let typename = info.and_then(|info| info.typename.clone().map(graph_editor::Type));
-        if let Some(node_id) = self.node_views.borrow().get_by_left(&id).cloned() {
+        if let Some(node_id) = self.node_view_by_expression.borrow().get(&id).cloned() {
             self.set_type(node_id,id,typename);
             let method_pointer = info.and_then(|info| {
                 info.method_call.and_then(|entry_id| {

--- a/src/rust/ide/src/view/integration.rs
+++ b/src/rust/ide/src/view/integration.rs
@@ -354,14 +354,14 @@ impl Model {
     , text          : controller::Text
     , visualization : controller::Visualization
     , project       : model::Project) -> Self {
-        let node_views       = default();
+        let node_views              = default();
         let node_view_by_expression = default();
-        let connection_views = default();
-        let expression_views = default();
-        let code_view        = default();
-        let visualizations   = default();
-        let searcher         = default();
-        let this             = Model
+        let connection_views        = default();
+        let expression_views        = default();
+        let code_view               = default();
+        let visualizations          = default();
+        let searcher                = default();
+        let this                    = Model
             {view,graph,text,searcher,node_views,expression_views,connection_views,code_view,logger
             ,visualization,visualizations,project,node_view_by_expression};
 

--- a/src/rust/ide/view/graph-editor/src/lib.rs
+++ b/src/rust/ide/view/graph-editor/src/lib.rs
@@ -1236,7 +1236,6 @@ impl GraphEditorModel {
 
 impl GraphEditorModel {
     fn remove_edge<E:Into<EdgeId>>(&self, edge_id:E) {
-        println!("REMOVE EDGE");
         let edge_id = edge_id.into();
         if let Some(edge) = self.edges.remove(&edge_id) {
             if let Some(source) = edge.take_source() {
@@ -1840,7 +1839,6 @@ fn new_graph_editor(app:&Application) -> GraphEditor {
     // ========================
 
     frp::extend! { network
-
         no_vis_selected   <- out.some_visualisation_selected.on_false();
         some_vis_selected <- out.some_visualisation_selected.on_true();
 

--- a/src/rust/ide/view/src/debug_scenes/interface.rs
+++ b/src/rust/ide/view/src/debug_scenes/interface.rs
@@ -84,7 +84,7 @@ impl DummyTypeGenerator {
 fn init(app:&Application) {
 
     theme::builtin::dark::setup(&app);
-    // theme::builtin::light::setup(&app);
+    theme::builtin::light::setup(&app);
 
     let _bg = app.display.scene().style_sheet.var(theme::application::background);
 
@@ -104,16 +104,31 @@ fn init(app:&Application) {
 
     code_editor.text_area().set_content(STUB_MODULE.to_owned());
 
+
+    // === Nodes ===
+
     let node1_id = graph_editor.add_node();
     let node2_id = graph_editor.add_node();
 
     graph_editor.frp.set_node_position.emit((node1_id,Vector2(-150.0,50.0)));
     graph_editor.frp.set_node_position.emit((node2_id,Vector2(50.0,50.0)));
 
-    let mut dummy_type_generator = DummyTypeGenerator::default();
     let expression_1 = expression_mock();
     graph_editor.frp.set_node_expression.emit((node1_id,expression_1.clone()));
+    let expression_2 = expression_mock3();
+    graph_editor.frp.set_node_expression.emit((node2_id,expression_2.clone()));
 
+
+    // === Connections ===
+
+    let src = graph_editor::EdgeEndpoint::new(node1_id,span_tree::Crumbs::new(default()));
+    let tgt = graph_editor::EdgeEndpoint::new(node2_id,span_tree::Crumbs::new(vec![0,0,0,0,1]));
+    graph_editor.frp.connect_nodes.emit((src,tgt));
+
+
+    // === Types (Port Coloring) ===
+
+    let mut dummy_type_generator = DummyTypeGenerator::default();
     expression_1.input_span_tree.root_ref().leaf_iter().for_each(|node|{
         if let Some(expr_id) = node.ast_id {
             let dummy_type = Some(dummy_type_generator.get_dummy_type());
@@ -127,8 +142,6 @@ fn init(app:&Application) {
         }
     });
 
-    let expression_2 = expression_mock3();
-    graph_editor.frp.set_node_expression.emit((node2_id,expression_2.clone()));
     expression_2.input_span_tree.root_ref().leaf_iter().for_each(|node|{
         if let Some(expr_id) = node.ast_id {
             let dummy_type = Some(dummy_type_generator.get_dummy_type());
@@ -141,10 +154,6 @@ fn init(app:&Application) {
             graph_editor.frp.set_expression_usage_type.emit((node2_id,expr_id,dummy_type));
         }
     });
-
-    let src = graph_editor::EdgeEndpoint::new(node1_id,span_tree::Crumbs::new(default()));
-    let tgt = graph_editor::EdgeEndpoint::new(node2_id,span_tree::Crumbs::new(vec![0,0,0,0,1]));
-    graph_editor.frp.connect_nodes.emit((src,tgt));
 
 
     let _tgt_type = dummy_type_generator.get_dummy_type();


### PR DESCRIPTION
### Pull Request Description
Fixes the port coloring: before we checked the expression id for being a node id, omitting all sub-expressions. Now we remember what subexpression id belongs to what node view and inform about types of all.

Coloring connections however still does not work. This pr includes a change in interface debug scene to show the problem: edges don't react for their endpoints' types changes.

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/main/docs/style-guide/rust.md) style guide.
- [x] All code has automatic tests where possible.
- [x] All code has been profiled where possible.
- [x] All code has been manually tested in the IDE.
- [x] All code has been manually tested in the "debug/interface" scene. - mind the "regression" described above.
- [x] All code has been manually tested by the PR owner against our [test scenarios](https://docs.google.com/spreadsheets/d/1RatJDM_f9_3bvYhl3Bpq2d8SyKgtVdrV1RkGxPU17c8/edit?ts=5faa7049#gid=0).
- [ ] All code has been manually tested by at least one reviewer against our [test scenarios](https://docs.google.com/spreadsheets/d/1RatJDM_f9_3bvYhl3Bpq2d8SyKgtVdrV1RkGxPU17c8/edit?ts=5faa7049#gid=0).

