### PR TITLE
Avoid changing edit status of project name when selecting it

### DIFF
--- a/src/rust/ide/view/graph-editor/src/component/breadcrumbs/project_name.rs
+++ b/src/rust/ide/view/graph-editor/src/component/breadcrumbs/project_name.rs
@@ -70,7 +70,9 @@ ensogl::define_endpoints! {
        /// Commit current project name.
        commit             (),
        outside_press      (),
+       /// Indicates that this is the currenlty active breadcrumb.
        select             (),
+       /// Indicates that this is not the currenlty active breadcrumb.
        deselect           (),
        /// Indicates the IDE is in edit mode. This means a click on some editable text should
        /// start editing it.
@@ -315,20 +317,16 @@ impl ProjectName {
 
             // === Selection ===
 
-            select <- any(&frp.select,&frp.input.start_editing);
-            eval_  select([text,animations]{
-                text.set_focus(true);
-                animations.color.set_target_value(selected_color);
-            });
-            frp.output.source.selected <+ select.to_true();
+            eval_ frp.select( animations.color.set_target_value(selected_color) );
+            frp.output.source.selected <+ frp.select.to_true();
 
-            deselect <- any3(&frp.deselect,&end_edit_mode,&outside_press);
-            eval_ deselect ([text,animations]{
+            set_inactive <- any3(&frp.deselect,&end_edit_mode,&outside_press);
+            eval_ set_inactive ([text,animations]{
                 text.set_focus(false);
                 text.remove_all_cursors();
                 animations.color.set_target_value(deselected_color);
             });
-            frp.output.source.selected <+ deselect.to_false();
+            frp.output.source.selected <+ set_inactive.to_false();
 
 
             // === Animations ===


### PR DESCRIPTION
### Pull Request Description
Avoids setting focus for the text field of the project name when it is set "selected", that is, when it is the current active breadcrumb level. 

### Important Notes
Adds some docs to clarify what "selected" in the API means. This was misleading before. 

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guide.
- [x] All code has automatic tests where possible.
- [x] All code has been profiled where possible.
- [x] All code has been manually tested in the IDE.
- [ ] ~All code has been manually tested in the "debug/interface" scene.~ - Cannot be tested because we don't have collapsed nodes in the debug scene. 
- [x] All code has been manually tested by the PR owner against our [test scenarios](https://docs.google.com/spreadsheets/d/1RatJDM_f9_3bvYhl3Bpq2d8SyKgtVdrV1RkGxPU17c8/edit?ts=5faa7049#gid=0).
- [x] All code has been manually tested by at least one reviewer against our [test scenarios](https://docs.google.com/spreadsheets/d/1RatJDM_f9_3bvYhl3Bpq2d8SyKgtVdrV1RkGxPU17c8/edit?ts=5faa7049#gid=0).

