### PR TITLE
Avoid updating positions of nodes during type updates.

### DIFF
--- a/src/rust/ide/src/controller/graph.rs
+++ b/src/rust/ide/src/controller/graph.rs
@@ -68,6 +68,8 @@ pub struct NoPatternOnNode {
 pub enum Notification {
     /// The content should be fully reloaded.
     Invalidate,
+    /// The graph expressions need updating, e.g., types, names, ports.
+    ExpressionUpdate,
 }
 
 
@@ -819,7 +821,7 @@ impl Handle {
         });
         let db_sub = self.suggestion_db.subscribe().map(|notification| {
             match notification {
-                model::suggestion_database::Notification::Updated => Notification::Invalidate
+                model::suggestion_database::Notification::Updated => Notification::ExpressionUpdate
             }
         });
         futures::stream::select(module_sub,db_sub)
@@ -996,7 +998,7 @@ pub mod tests {
     }
 
     #[wasm_bindgen_test]
-    fn suggestion_db_updates_invalidate_graph() {
+    fn suggestion_db_updates_graph_values() {
         Fixture::set_up().run(|graph| async move {
             let mut sub = graph.subscribe();
             let update = language_server::types::SuggestionDatabaseUpdatesEvent {
@@ -1004,7 +1006,7 @@ pub mod tests {
                 current_version : default(),
             };
             graph.suggestion_db.apply_update_event(update);
-            assert_eq!(Some(Notification::Invalidate), sub.next().await);
+            assert_eq!(Some(Notification::ExpressionUpdate), sub.next().await);
         });
     }
 

--- a/src/rust/ide/src/controller/graph.rs
+++ b/src/rust/ide/src/controller/graph.rs
@@ -68,8 +68,8 @@ pub struct NoPatternOnNode {
 pub enum Notification {
     /// The content should be fully reloaded.
     Invalidate,
-    /// The graph expressions need updating, e.g., types, names, ports.
-    ExpressionUpdate,
+    /// The graph node's ports need updating, e.g., types, names.
+    PortsUpdate,
 }
 
 
@@ -821,7 +821,7 @@ impl Handle {
         });
         let db_sub = self.suggestion_db.subscribe().map(|notification| {
             match notification {
-                model::suggestion_database::Notification::Updated => Notification::ExpressionUpdate
+                model::suggestion_database::Notification::Updated => Notification::PortsUpdate
             }
         });
         futures::stream::select(module_sub,db_sub)
@@ -1006,7 +1006,7 @@ pub mod tests {
                 current_version : default(),
             };
             graph.suggestion_db.apply_update_event(update);
-            assert_eq!(Some(Notification::ExpressionUpdate), sub.next().await);
+            assert_eq!(Some(Notification::PortsUpdate), sub.next().await);
         });
     }
 

--- a/src/rust/ide/src/controller/graph/executed.rs
+++ b/src/rust/ide/src/controller/graph/executed.rs
@@ -152,11 +152,11 @@ impl Handle {
         let db_stream = self.project.suggestion_db().subscribe().map(|notification| {
             match notification {
                 model::suggestion_database::Notification::Updated =>
-                    Notification::Graph(controller::graph::Notification::Invalidate),
+                    Notification::Graph(controller::graph::Notification::ExpressionUpdate),
             }
         }).boxed_local();
         let update_stream = registry.subscribe().map(|_| {
-            Notification::Graph(controller::graph::Notification::Invalidate)
+            Notification::Graph(controller::graph::Notification::ExpressionUpdate)
         }).boxed_local();
 
         let streams = vec![value_stream,graph_stream,self_stream,db_stream,update_stream];
@@ -374,7 +374,7 @@ pub mod tests {
             },
             |notification| match notification {
                 Notification::Graph(graph_notification) => {
-                    assert_eq!(graph_notification,&controller::graph::Notification::Invalidate);
+                    assert_eq!(graph_notification,&controller::graph::Notification::ExpressionUpdate);
                     true
                 }
                 _ => false,

--- a/src/rust/ide/src/controller/graph/executed.rs
+++ b/src/rust/ide/src/controller/graph/executed.rs
@@ -152,11 +152,11 @@ impl Handle {
         let db_stream = self.project.suggestion_db().subscribe().map(|notification| {
             match notification {
                 model::suggestion_database::Notification::Updated =>
-                    Notification::Graph(controller::graph::Notification::ExpressionUpdate),
+                    Notification::Graph(controller::graph::Notification::PortsUpdate),
             }
         }).boxed_local();
         let update_stream = registry.subscribe().map(|_| {
-            Notification::Graph(controller::graph::Notification::ExpressionUpdate)
+            Notification::Graph(controller::graph::Notification::PortsUpdate)
         }).boxed_local();
 
         let streams = vec![value_stream,graph_stream,self_stream,db_stream,update_stream];
@@ -374,7 +374,7 @@ pub mod tests {
             },
             |notification| match notification {
                 Notification::Graph(graph_notification) => {
-                    assert_eq!(graph_notification,&controller::graph::Notification::ExpressionUpdate);
+                    assert_eq!(graph_notification,&controller::graph::Notification::PortsUpdate);
                     true
                 }
                 _ => false,

--- a/src/rust/ide/src/view/integration.rs
+++ b/src/rust/ide/src/view/integration.rs
@@ -442,13 +442,13 @@ impl Model {
         info!(self.logger, "Refreshing the graph view.");
         use controller::graph::Connections;
         let Connections{trees,connections} = self.graph.connections()?;
-        self.refresh_node_views(trees)?;
+        self.refresh_node_views(trees, true)?;
         self.refresh_connection_views(connections)?;
         Ok(())
     }
 
     fn refresh_node_views
-    (&self, mut trees:HashMap<double_representation::node::Id,NodeTrees>) -> FallibleResult {
+    (&self, mut trees:HashMap<double_representation::node::Id,NodeTrees>,update_position:bool) -> FallibleResult {
         let nodes = self.graph.graph().nodes()?;
         let ids   = nodes.iter().map(|node| node.info.id() ).collect();
         self.retain_node_views(&ids);
@@ -460,11 +460,23 @@ impl Model {
             let default_pos = Vector2(x,y);
             let displayed   = self.node_views.borrow_mut().get_by_left(&id).cloned();
             match displayed {
-                Some(displayed) => self.refresh_node_view(displayed,node_info,node_trees),
-                None            => self.create_node_view(node_info,node_trees,default_pos),
+                Some(displayed) => {
+                   if update_position {
+                       self.refresh_node_position(displayed,node_info)
+                   };
+                   self.refresh_node_expression(displayed, node_info, node_trees);
+                },
+                None => self.create_node_view(node_info,node_trees,default_pos),
             }
         }
         Ok(())
+    }
+
+    /// Refresh the expressions (e.g., types, ports) for all nodes.
+    fn refresh_graph_expressions(&self) -> FallibleResult  {
+        info!(self.logger, "Refreshing the graph expressions.");
+        let trees = self.graph.connections()?.trees;
+        self.refresh_node_views(trees, false)
     }
 
     /// Retain only given nodes in displayed graph.
@@ -529,10 +541,20 @@ impl Model {
 
     fn refresh_node_view
     (&self, id:graph_editor::NodeId, node:&controller::graph::Node, trees:NodeTrees) {
+        self.refresh_node_position(id,node);
+        self.refresh_node_expression(id, node, trees)
+    }
+
+    /// Update the position of the node based on its current metadata.
+    fn refresh_node_position(&self, id:graph_editor::NodeId, node:&controller::graph::Node) {
         let position = node.metadata.as_ref().and_then(|md| md.position);
         if let Some(position) = position {
             self.view.graph().frp.input.set_node_position.emit(&(id, position.vector));
         }
+    }
+
+    /// Update the expression of the node and all related properties e.g., types, ports).
+    fn refresh_node_expression(&self, id:graph_editor::NodeId, node:&controller::graph::Node, trees:NodeTrees) {
         let expression     = node.info.expression().repr();
         let code_and_trees = graph_editor::component::node::Expression {
             code             : expression,
@@ -651,6 +673,11 @@ impl Model {
         self.refresh_graph_view()
     }
 
+    /// Handle notification received from controller about the graph receiving new type information.
+    pub fn on_graph_expression_update(&self) -> FallibleResult {
+        self.refresh_graph_expressions()
+    }
+
     /// Handle notification received from controller about the whole graph being invalidated.
     pub fn on_text_invalidated(&self) -> FallibleResult {
         self.refresh_code_editor()
@@ -701,16 +728,17 @@ impl Model {
     pub fn handle_graph_notification
     (&self, notification:&Option<controller::graph::executed::Notification>) {
         use controller::graph::executed::Notification;
-        use controller::graph::Notification::Invalidate;
+        use controller::graph::Notification::*;
 
         debug!(self.logger, "Received notification {notification:?}");
         let result = match notification {
             Some(Notification::Graph(Invalidate))         => self.on_graph_invalidated(),
+            Some(Notification::Graph(ExpressionUpdate))      => self.on_graph_expression_update(),
             Some(Notification::ComputedValueInfo(update)) => self.on_values_computed(update),
             Some(Notification::SteppedOutOfNode(id))      => self.on_node_exited(*id),
             Some(Notification::EnteredNode(local_call))   => self.on_node_entered(local_call),
-            other => {
-                warning!(self.logger,"Handling notification {other:?} is not implemented; \
+            None => {
+                warning!(self.logger,"Handling `None` notification is not implemented; \
                     performing full invalidation");
                 self.refresh_graph_view()
             }

--- a/src/rust/ide/src/view/integration.rs
+++ b/src/rust/ide/src/view/integration.rs
@@ -448,7 +448,7 @@ impl Model {
     }
 
     fn refresh_node_views
-    (&self, mut trees:HashMap<double_representation::node::Id,NodeTrees>,update_position:bool) -> FallibleResult {
+    (&self, mut trees:HashMap<double_representation::node::Id,NodeTrees>, update_position:bool) -> FallibleResult {
         let nodes = self.graph.graph().nodes()?;
         let ids   = nodes.iter().map(|node| node.info.id() ).collect();
         self.retain_node_views(&ids);
@@ -1223,5 +1223,4 @@ impl ide_view::searcher::DocumentationProvider for DataProviderForView {
         }
     }
 }
-
 

--- a/src/rust/ide/src/view/integration.rs
+++ b/src/rust/ide/src/view/integration.rs
@@ -733,7 +733,7 @@ impl Model {
         debug!(self.logger, "Received notification {notification:?}");
         let result = match notification {
             Some(Notification::Graph(Invalidate))         => self.on_graph_invalidated(),
-            Some(Notification::Graph(ExpressionUpdate))   => self.on_graph_expression_update(),
+            Some(Notification::Graph(PortsUpdate))   => self.on_graph_expression_update(),
             Some(Notification::ComputedValueInfo(update)) => self.on_values_computed(update),
             Some(Notification::SteppedOutOfNode(id))      => self.on_node_exited(*id),
             Some(Notification::EnteredNode(local_call))   => self.on_node_entered(local_call),

--- a/src/rust/ide/src/view/integration.rs
+++ b/src/rust/ide/src/view/integration.rs
@@ -733,7 +733,7 @@ impl Model {
         debug!(self.logger, "Received notification {notification:?}");
         let result = match notification {
             Some(Notification::Graph(Invalidate))         => self.on_graph_invalidated(),
-            Some(Notification::Graph(ExpressionUpdate))      => self.on_graph_expression_update(),
+            Some(Notification::Graph(ExpressionUpdate))   => self.on_graph_expression_update(),
             Some(Notification::ComputedValueInfo(update)) => self.on_values_computed(update),
             Some(Notification::SteppedOutOfNode(id))      => self.on_node_exited(*id),
             Some(Notification::EnteredNode(local_call))   => self.on_node_entered(local_call),
@@ -1223,4 +1223,3 @@ impl ide_view::searcher::DocumentationProvider for DataProviderForView {
         }
     }
 }
-


### PR DESCRIPTION
### Pull Request Description
Adds a new update notification in the controller part, that indicates that the node expressions of a graph should be updated, but not the node positions.


### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guide.
- [x] All code has automatic tests where possible.
- [x] All code has been profiled where possible.
- [x] All code has been manually tested in the IDE.
- [ ] ~All code has been manually tested in the "debug/interface" scene.~ Requires language server integration. 
- [x] All code has been manually tested by the PR owner against our [test scenarios](https://docs.google.com/spreadsheets/d/1RatJDM_f9_3bvYhl3Bpq2d8SyKgtVdrV1RkGxPU17c8/edit?ts=5faa7049#gid=0).
- [x] All code has been manually tested by at least one reviewer against our [test scenarios](https://docs.google.com/spreadsheets/d/1RatJDM_f9_3bvYhl3Bpq2d8SyKgtVdrV1RkGxPU17c8/edit?ts=5faa7049#gid=0).

