### PR TITLE
Remove blockmap generation when building electron package.

### DIFF
--- a/src/js/lib/client/package.js
+++ b/src/js/lib/client/package.js
@@ -73,6 +73,24 @@ config.build = {
     directories: {
         output: paths.dist.client,
     },
+    nsis: {
+        // Disables "block map" generation during electron building. Block maps 
+        // can be used for incremental package update on client-side. However,
+        // their generation can take long time (even 30 mins), so we removed it
+        // for now. Moreover, we may probably never need them, as our updates
+        // are handled by us. More info: 
+        // https://github.com/electron-userland/electron-builder/issues/2900
+        differentialPackage: false
+    },
+    dmg: {
+        // Disables "block map" generation during electron building. Block maps 
+        // can be used for incremental package update on client-side. However,
+        // their generation can take long time (even 30 mins), so we removed it
+        // for now. Moreover, we may probably never need them, as our updates
+        // are handled by us. More info: 
+        // https://github.com/electron-userland/electron-builder/issues/2900
+        writeUpdateInfo: false
+    },
     publish: [],
 }
 

--- a/src/js/lib/client/package.js
+++ b/src/js/lib/client/package.js
@@ -79,6 +79,7 @@ config.build = {
         // their generation can take long time (even 30 mins), so we removed it
         // for now. Moreover, we may probably never need them, as our updates
         // are handled by us. More info: 
+        // https://github.com/electron-userland/electron-builder/issues/2851
         // https://github.com/electron-userland/electron-builder/issues/2900
         differentialPackage: false
     },
@@ -88,6 +89,7 @@ config.build = {
         // their generation can take long time (even 30 mins), so we removed it
         // for now. Moreover, we may probably never need them, as our updates
         // are handled by us. More info: 
+        // https://github.com/electron-userland/electron-builder/issues/2851
         // https://github.com/electron-userland/electron-builder/issues/2900
         writeUpdateInfo: false
     },


### PR DESCRIPTION
### Pull Request Description
This PR removes block map generation when building the electron package. According to our source code comment:

```
        // Disables "block map" generation during electron building. Block maps 
        // can be used for incremental package update on client-side. However,
        // their generation can take long time (even 30 mins), so we removed it
        // for now. Moreover, we may probably never need them, as our updates
        // are handled by us. More info: 
        // https://github.com/electron-userland/electron-builder/issues/2851
        // https://github.com/electron-userland/electron-builder/issues/2900
```

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guide.
- [x] All code has automatic tests where possible.
- [x] All code has been profiled where possible.
- [x] All code has been manually tested in the IDE.
- [x] All code has been manually tested in the "debug/interface" scene.
- [x] All code has been manually tested by the PR owner against our [test scenarios](https://docs.google.com/spreadsheets/d/1RatJDM_f9_3bvYhl3Bpq2d8SyKgtVdrV1RkGxPU17c8/edit?ts=5faa7049#gid=0).
- [ ] ~All code has been manually tested by at least one reviewer against our [test scenarios](https://docs.google.com/spreadsheets/d/1RatJDM_f9_3bvYhl3Bpq2d8SyKgtVdrV1RkGxPU17c8/edit?ts=5faa7049#gid=0).~ **(does not need to be done, this feature is not affecting the working of the app)**

