### PR TITLE
chore: make bug template give better reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -12,22 +12,17 @@ Please ensure that you are using the latest version of Enso IDE before reporting
 the bug! It may have been fixed since.
 -->
 
-### General Summary
+### What did you do?
 <!--
-- Please include a high-level description of your bug here.
+If possible, provide a recipe for reproducing the bug.
 -->
 
-### Steps to Reproduce
+### What did you expect to see?
 <!--
-Please list the reproduction steps for your bug.
+- A description of the results you expected to get from the recipe above.
 -->
 
-### Expected Result
-<!--
-- A description of the results you expected from the reproduction steps.
--->
-
-### Actual Result
+### What did you see instead?
 <!--
 - A description of what actually happens when you perform these steps.
 - Please include any error output if relevant.
@@ -37,3 +32,5 @@ Please list the reproduction steps for your bug.
 <!--
 - Please include the version of Enso IDE you are using here.
 -->
+
+### Additional notes


### PR DESCRIPTION
I would highly recommend that you modify the bug report template, such that it doesn't have "description" first and "steps to reproduce" below, but just immediately start from "steps to reproduce"; see e.g. https://github.com/golang/go/blob/master/.github/ISSUE_TEMPLATE (from which I blatantly copied some parts; using good sources is a virtue).

The problem is, when a template starts with "description", I (a reporter) start filling it with freeform and somewhat chaotic, unstructured words basically describing the problem and maybe how I came to it; but then I have to repeat most of this work in "steps to reproduce" which is annoying and discouraging.

On the other hand, starting immediately from "steps to reproduce" (in the Go issue template: "What did you do?", which is a bit more open) helps both you and me, because it immediately softly leads me (or another reporter) to start writing it in a structured way that will most useful to you, and doesn't make me feel like I'm repeating myself soon afterwards.

