### PR TITLE
Fix aliasing artficats on repeated shapes: Correct repeat shape function to not cut of shapes.

### DIFF
--- a/src/rust/ensogl/lib/core/src/display/shape/primitive/glsl/shape.glsl
+++ b/src/rust/ensogl/lib/core/src/display/shape/primitive/glsl/shape.glsl
@@ -338,5 +338,5 @@ vec2 cartesian2polar (vec2 position) {
 }
 
 vec2 repeat (vec2 position, vec2 tile_size) {
-    return mod(position-tile_size/2.0, tile_size);
+    return mod(position+tile_size/2.0, tile_size) - tile_size/2.0;
 }

--- a/src/rust/ensogl/lib/core/src/display/shape/primitive/shader/canvas.rs
+++ b/src/rust/ensogl/lib/core/src/display/shape/primitive/shader/canvas.rs
@@ -304,7 +304,7 @@ impl Canvas {
     (&mut self, num:usize, s:Shape, tile_size:T) -> Shape {
         self.if_not_defined(num, |this| {
             let value:Glsl = tile_size.into().glsl();
-            let repeat     = iformat!("position = mod(position,{value});");
+            let repeat     = iformat!("position = repeat(position,{value});");
             let expr       = iformat!("return withInfiniteBounds({s.getter()});");
             this.add_current_function_code_line(repeat);
             let mut shape  = this.new_shape_from_expr(num,&expr);

--- a/src/rust/ide/view/graph-editor/src/component/node.rs
+++ b/src/rust/ide/view/graph-editor/src/component/node.rs
@@ -49,7 +49,7 @@ pub const RADIUS            : f32 = 14.0;
 pub const SHADOW_SIZE       : f32 = 10.0;
 
 const INFINITE                       : f32       = 99999.0;
-const ERROR_PATTERN_STRIPE_WIDTH     : f32       = 10.0;
+const ERROR_PATTERN_STRIPE_WIDTH     : f32       = 5.0;
 const ERROR_PATTERN_STRIPE_ANGLE     : f32       = 45.0;
 const ERROR_PATTERN_REPEAT_TILE_SIZE : (f32,f32) = (15.0,15.0);
 const ERROR_BORDER_WIDTH             : f32       = 10.0;


### PR DESCRIPTION
### Pull Request Description
Correct the rep[eat shape operation to not cut of shapes, which in turn corrects the aliasing issue. 

![image](https://user-images.githubusercontent.com/1428930/107536075-acfc2d00-6bc1-11eb-8e71-507f6f3716b2.png)

### Important Notes
Also adjust the stripe pattern on error nodes, as these need to be halved to look as before. 


### Checklist
Please include the following checklist in your PR:

- [x] The `CHANGELOG.md` was updated with the changes introduced in this PR.
- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guide.
- [x] All code has automatic tests where possible.
- [x] All code has been profiled where possible.
- [x] All code has been manually tested in the IDE.
- [x] All code has been manually tested in the "debug/interface" scene.
- [x] All code has been manually tested by the PR owner against our [test scenarios](https://docs.google.com/spreadsheets/d/1RatJDM_f9_3bvYhl3Bpq2d8SyKgtVdrV1RkGxPU17c8/edit?ts=5faa7049#gid=0).
- [ ] All code has been manually tested by at least one reviewer against our [test scenarios](https://docs.google.com/spreadsheets/d/1RatJDM_f9_3bvYhl3Bpq2d8SyKgtVdrV1RkGxPU17c8/edit?ts=5faa7049#gid=0).
