### PR TITLE
Change visualization reload shortcut

### DIFF
--- a/docs/product/shortcuts.md
+++ b/docs/product/shortcuts.md
@@ -117,4 +117,4 @@ further investigation.
 | <kbd>ctrl</kbd> + <kbd>d</kbd>                                     | Send test data to the selected node. |
 | <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>enter</kbd>              | Push a hardcoded breadcrumb without navigating. |
 | <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>arrow up</kbd>           | Pop a breadcrumb without navigating. |
-| <kbd>cmd</kbd>  + <kbd>shift</kbd> + <kbd>alt</kbd> + <kbd>r</kbd> | Reload visualizations. To see the effect in the currently shown visualizations, you need to switch to another and switch back. |
+| <kbd>cmd</kbd>  + <kbd>i</kbd>                                     | Reload visualizations. To see the effect in the currently shown visualizations, you need to switch to another and switch back. |

--- a/src/rust/ide/view/graph-editor/src/lib.rs
+++ b/src/rust/ide/view/graph-editor/src/lib.rs
@@ -1839,7 +1839,7 @@ impl application::View for GraphEditor {
           , (Press       , "!node_editing" , "space" , "press_visualization_visibility")
           // , (DoublePress , "!node_editing" , "space" , "double_press_visualization_visibility")
           , (Release     , "!node_editing" , "space" , "release_visualization_visibility")
-          , (Press       , "", "cmd shift alt r"     , "reload_visualization_registry")
+          , (Press       , ""              , "cmd i" , "reload_visualization_registry")
 
           // === Selection ===
           , (Press   , "" , "shift"                   , "enable_node_multi_select")


### PR DESCRIPTION
### Pull Request Description
The cmd+shift+alt+r is apparently doing weird things in electron. To avoid conflicts, the shortcut has been changed to simple cmd+i

### Important Notes


### Checklist
Please include the following checklist in your PR:

- [ ] ~~The `CHANGELOG.md` was updated with the changes introduced in this PR.~~
- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guide.
- [ ] ~~All code has automatic tests where possible.~~
- [ ] ~~All code has been profiled where possible.~~
- [x] All code has been manually tested in the IDE.
- [x] All code has been manually tested in the "debug/interface" scene.
- [ ] All code has been manually tested by the PR owner against our [test scenarios](https://docs.google.com/spreadsheets/d/1RatJDM_f9_3bvYhl3Bpq2d8SyKgtVdrV1RkGxPU17c8/edit?ts=5faa7049#gid=0).
- [ ] All code has been manually tested by at least one reviewer against our [test scenarios](https://docs.google.com/spreadsheets/d/1RatJDM_f9_3bvYhl3Bpq2d8SyKgtVdrV1RkGxPU17c8/edit?ts=5faa7049#gid=0).
