### PR TITLE
Update controller to take into account visualisation metadata from the IDE when attaching a visualisation.

### DIFF
--- a/src/rust/ide/src/ide/integration.rs
+++ b/src/rust/ide/src/ide/integration.rs
@@ -1047,7 +1047,7 @@ impl Model {
         let module_name          = crate::ide::INITIAL_MODULE_NAME;
         let visualisation_module = QualifiedName::from_segments(project_name,&[module_name])?;
         let id                   = VisualizationId::new_v4();
-        let metadata_expression  = metadata.and_then(|m| m.expression.as_ref().map(|e| e.to_string()));
+        let metadata_expression  = metadata.and_then(|m| m.preprocessor.as_ref().map(|e| e.to_string()));
         let default_expression   = crate::constants::SERIALIZE_TO_JSON_EXPRESSION;
         let expression           = metadata_expression.unwrap_or_else(||default_expression.into());
         let ast_id               = self.get_controller_node_id(*node_id)?;

--- a/src/rust/ide/src/ide/integration.rs
+++ b/src/rust/ide/src/ide/integration.rs
@@ -1006,8 +1006,10 @@ impl Model {
     /// Create a controller-compatible description of the visualization based on the input received
     /// from the graph editor endpoints.
     fn prepare_visualization
-    (&self, node_id:&graph_editor::NodeId) -> FallibleResult<Visualization> {
+    (&self, node_id:&graph_editor::NodeId, metadata:&Option<visualization::Metadata>)
+    -> FallibleResult<Visualization> {
         use crate::model::module::QualifiedName;
+        let metadata = metadata.as_ref();
 
         // TODO [mwu]
         //   Currently it is not possible to:
@@ -1021,18 +1023,23 @@ impl Model {
         let module_name          = crate::ide::INITIAL_MODULE_NAME;
         let visualisation_module = QualifiedName::from_segments(project_name,&[module_name])?;
         let id                   = VisualizationId::new_v4();
-        let expression           = crate::constants::SERIALIZE_TO_JSON_EXPRESSION.into();
+        let metadata_expression  = metadata.map(|m| m.expression.as_ref().map(|e| e.to_string()));
+        let metadata_expression  = metadata_expression.flatten();
+        let default_expression   = crate::constants::SERIALIZE_TO_JSON_EXPRESSION;
+        let expression           = metadata_expression.unwrap_or_else(||default_expression.into());
         let ast_id               = self.get_controller_node_id(*node_id)?;
         Ok(Visualization{ast_id,expression,id,visualisation_module})
     }
 
-    fn visualization_enabled_in_ui(&self, node_id:&graph_editor::NodeId) -> FallibleResult {
+    fn visualization_enabled_in_ui
+    (&self, (node_id,vis_metadata):&(graph_editor::NodeId,Option<visualization::Metadata>))
+    -> FallibleResult {
         // Do nothing if there is already a visualization attached.
         let err = || VisualizationAlreadyAttached(*node_id);
         self.get_controller_visualization_id(*node_id).is_err().ok_or_else(err)?;
 
         debug!(self.logger, "Attaching visualization on {node_id}.");
-        let visualization  = self.prepare_visualization(node_id)?;
+        let visualization  = self.prepare_visualization(node_id,vis_metadata)?;
         let id             = visualization.id;
         let node_id        = *node_id;
         let controller     = self.graph.clone();

--- a/src/rust/ide/src/ide/integration.rs
+++ b/src/rust/ide/src/ide/integration.rs
@@ -1047,8 +1047,7 @@ impl Model {
         let module_name          = crate::ide::INITIAL_MODULE_NAME;
         let visualisation_module = QualifiedName::from_segments(project_name,&[module_name])?;
         let id                   = VisualizationId::new_v4();
-        let metadata_expression  = metadata.map(|m| m.expression.as_ref().map(|e| e.to_string()));
-        let metadata_expression  = metadata_expression.flatten();
+        let metadata_expression  = metadata.and_then(|m| m.expression.as_ref().map(|e| e.to_string()));
         let default_expression   = crate::constants::SERIALIZE_TO_JSON_EXPRESSION;
         let expression           = metadata_expression.unwrap_or_else(||default_expression.into());
         let ast_id               = self.get_controller_node_id(*node_id)?;

--- a/src/rust/ide/view/graph-editor/src/component/visualization.rs
+++ b/src/rust/ide/view/graph-editor/src/component/visualization.rs
@@ -28,6 +28,7 @@ pub mod data;
 pub mod definition;
 pub mod foreign;
 pub mod instance;
+pub mod metadata;
 pub mod path;
 pub mod registry;
 
@@ -36,5 +37,6 @@ pub use data::*;
 pub use definition::*;
 pub use foreign::*;
 pub use instance::Instance;
+pub use metadata::*;
 pub use path::*;
 pub use registry::*;

--- a/src/rust/ide/view/graph-editor/src/component/visualization/metadata.rs
+++ b/src/rust/ide/view/graph-editor/src/component/visualization/metadata.rs
@@ -4,9 +4,11 @@ use crate::prelude::*;
 
 use crate::data::enso;
 
-/// Description of the visualization state in the IDE.
+/// Description of the visualization state, emitted with visualization_enabled event in GraphEditor.
 #[derive(Clone,Debug,Default)]
 pub struct Metadata {
-    /// An enso lambda that will transform the data into expected format, e.g. `a -> a.json`.
-    pub expression: Option<enso::Code>,
+    /// An Enso lambda, called on the Engine side before sending data to IDE, allowing us to do some
+    /// compression or filtering for the best performance. See also _Lazy Visualization_ section
+    /// [here](http://dev.enso.org/docs/ide/product/visualizations.html).
+    pub preprocessor: Option<enso::Code>,
 }

--- a/src/rust/ide/view/graph-editor/src/component/visualization/metadata.rs
+++ b/src/rust/ide/view/graph-editor/src/component/visualization/metadata.rs
@@ -1,0 +1,12 @@
+//! Visualization Metadata contains information about the runtime state of the visualization.
+
+use crate::prelude::*;
+
+use crate::data::enso;
+
+/// Description of the visualization state in the IDE.
+#[derive(Clone,Debug,Default)]
+pub struct Metadata {
+    /// An enso lambda that will transform the data into expected format, e.g. `a -> a.json`.
+    pub expression: Option<enso::Code>,
+}

--- a/src/rust/ide/view/graph-editor/src/lib.rs
+++ b/src/rust/ide/view/graph-editor/src/lib.rs
@@ -1088,8 +1088,8 @@ impl GraphEditorModelWithNetwork {
             output.source.on_visualization_select <+ deselected.constant(Switch::Off(node_id));
 
             metadata <- node.model.visualization.frp.preprocessor.map(move |code| {
-                let expression = Some(code.clone());
-                Some(visualization::Metadata{expression})
+                let preprocessor = Some(code.clone());
+                Some(visualization::Metadata{preprocessor})
             });
             // Ensure the graph editor knows about internal changes to the visualisation. If the
             // visualisation changes that should indicate that the old one has been disabled and a


### PR DESCRIPTION
### Pull Request Description
Add functionality to pass metadata information from the IDE to the controller. This allows us to retain information about detached information on the IDE side and pass it to the controller when attaching a visualization again. 

### Important Notes
This fixes visualizations loosing their preprocessor settings when hiding/showing. 

### Checklist
Please include the following checklist in your PR:

- [x] The `CHANGELOG.md` was updated with the changes introduced in this PR.
  - Does not require an entry as it fixes an unreleased bug that only exists on develop. 
- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guide.
- [x] All code has automatic tests where possible.
- [x] All code has been profiled where possible.
- [x] All code has been manually tested in the IDE.
- [ ] ~All code has been manually tested in the "debug/interface" scene.~
- [x] All code has been manually tested by the PR owner against our [test scenarios](https://docs.google.com/spreadsheets/d/1RatJDM_f9_3bvYhl3Bpq2d8SyKgtVdrV1RkGxPU17c8/edit?ts=5faa7049#gid=0).
- [x] All code has been manually tested by at least one reviewer against our [test scenarios](https://docs.google.com/spreadsheets/d/1RatJDM_f9_3bvYhl3Bpq2d8SyKgtVdrV1RkGxPU17c8/edit?ts=5faa7049#gid=0).
