### PR TITLE
Prevent IDE from failing to start when metadata are invalid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ read the notes of the `Enso 2.0.0-alpha.1` release.
 - [Assigning intermediate expressions to values][1067]. Nodes added with searcher will have their 
   values automatically assigned to a newly generated variables. This allows Enso Engine to cache
   intermediate values, improving visualization performance.
+- [Improved handling of projects created with other IDE versions][1214]. IDE is not better at 
+  dealing with incompatible node metadata (that store node visual positions, history of picked 
+  searcher suggestions, etc.). This will allow IDE to correctly open projects that were created 
+  using a different IDE version and prevent unnecessary lose of metadata information.
   
 #### EnsoGL
 - New multi-camera management system, allowing the same shape systems be rendered on different 
@@ -55,6 +59,7 @@ read the notes of the `Enso 2.0.0-alpha.1` release.
 [1160]: https://github.com/enso-org/ide/pull/1160
 [1190]: https://github.com/enso-org/ide/pull/1190
 [1187]: https://github.com/enso-org/ide/pull/1187
+[1214]: https://github.com/enso-org/ide/pull/1214
 <br/>
 
 

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -2853,6 +2853,8 @@ dependencies = [
  "failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-utils 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.116 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.58 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/src/rust/ide/lib/parser/src/api.rs
+++ b/src/rust/ide/lib/parser/src/api.rs
@@ -8,7 +8,6 @@ use enso_data::text::ByteIndex;
 
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
-use serde::Deserializer;
 use serde::Serialize;
 
 pub use ast::Ast;
@@ -130,7 +129,7 @@ pub struct ParsedSourceFile<Metadata> {
     pub ast: ast::known::Module,
     /// Raw metadata in json.
     #[serde(bound(deserialize = "Metadata:Default+DeserializeOwned"))]
-    #[serde(deserialize_with="deserialize_or_default")]
+    #[serde(deserialize_with="utils::serde::deserialize_or_default")]
     pub metadata: Metadata
 }
 
@@ -141,13 +140,6 @@ impl<M:Metadata> TryFrom<&ParsedSourceFile<M>> for String {
     }
 }
 
-/// Try to deserialize value of type `Ret`. In case of any error, it is ignored and the default
-/// value is returned instead.
-pub fn deserialize_or_default<'d,Ret,D>(d:D) -> std::result::Result<Ret,D::Error>
-where Ret : Default + Deserialize<'d>
-    , D   : Deserializer<'d> {
-    Ret::deserialize(d).or_else(|_error| Ok(Ret::default()))
-}
 
 
 // === Parsed Source File Serialization ===

--- a/src/rust/ide/lib/parser/src/api.rs
+++ b/src/rust/ide/lib/parser/src/api.rs
@@ -141,7 +141,6 @@ impl<M:Metadata> TryFrom<&ParsedSourceFile<M>> for String {
 }
 
 
-
 // === Parsed Source File Serialization ===
 
 const NEWLINES_BEFORE_TAG:usize = 3;

--- a/src/rust/ide/lib/parser/src/lib.rs
+++ b/src/rust/ide/lib/parser/src/lib.rs
@@ -85,6 +85,9 @@ impl Parser {
 
     /// Parse contents of the program source file, where program code may be followed by idmap and
     /// metadata.
+    ///
+    /// If metadata deserialization fails, error is ignored and default value for metadata is used.
+    /// Other errors are returned through `Result`.
     pub fn parse_with_metadata<M:api::Metadata>
     (&self, program:String) -> api::Result<api::ParsedSourceFile<M>> {
         self.borrow_mut().parse_with_metadata(program)

--- a/src/rust/ide/lib/parser/src/wsclient.rs
+++ b/src/rust/ide/lib/parser/src/wsclient.rs
@@ -13,6 +13,7 @@ use api::Error::*;
 use api::ParsedSourceFile;
 use ast::IdMap;
 
+use serde::de::DeserializeOwned;
 use std::fmt::Formatter;
 
 type WsTcpClient = websocket::sync::Client<TcpStream>;
@@ -98,6 +99,7 @@ pub enum Request {
 /// All responses that Parser Service might reply with.
 #[derive(Debug, serde::Deserialize)]
 pub enum Response<Metadata> {
+    #[serde(bound(deserialize = "Metadata:Default+DeserializeOwned"))]
     Success { module  : ParsedSourceFile<Metadata> },
     Error   { message : String                     },
 }

--- a/src/rust/ide/lib/utils/Cargo.toml
+++ b/src/rust/ide/lib/utils/Cargo.toml
@@ -13,3 +13,5 @@ enso-shapely = { version = "0.1.4" }
 failure   = "0.1.5"
 futures   = "0.3.1"
 pin-utils = "0.1.0-alpha.4"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = { version = "1.0" }

--- a/src/rust/ide/lib/utils/Cargo.toml
+++ b/src/rust/ide/lib/utils/Cargo.toml
@@ -8,10 +8,11 @@ edition = "2018"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-enso-prelude = { version = "0.1.10" }
-enso-shapely = { version = "0.1.4" }
-failure   = "0.1.5"
-futures   = "0.3.1"
-pin-utils = "0.1.0-alpha.4"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = { version = "1.0" }
+enso-prelude = { version = "0.1.10"                     }
+enso-shapely = { version = "0.1.4 "                     }
+serde        = { version = "1.0", features = ["derive"] }
+serde_json   = { version = "1.0"                        }
+
+failure      = "0.1.5"
+futures      = "0.3.1"
+pin-utils    = "0.1.0-alpha.4"

--- a/src/rust/ide/lib/utils/src/lib.rs
+++ b/src/rust/ide/lib/utils/src/lib.rs
@@ -17,6 +17,7 @@ pub mod channel;
 pub mod env;
 pub mod fail;
 pub mod future;
+pub mod serde;
 pub mod string;
 pub mod test;
 pub mod vec;

--- a/src/rust/ide/lib/utils/src/serde.rs
+++ b/src/rust/ide/lib/utils/src/serde.rs
@@ -9,8 +9,8 @@ use serde::Deserializer;
 /// Try to deserialize value of type `Ret`. In case of any error, it is ignored and the default
 /// value is returned instead.
 pub fn deserialize_or_default<'d,Ret,D>(d:D) -> Result<Ret,D::Error>
-    where for<'e> Ret : Default + Deserialize<'e>
-    ,         D   : Deserializer<'d> {
+where for<'e> Ret : Default + Deserialize<'e>
+,             D   : Deserializer<'d> {
     // We first parse as generic JSON value. This is necessary to consume parser input.
     // If we just tried parsing the desired type directly and ignored error, we would end up with
     // `trailing characters` error in non-trivial cases.

--- a/src/rust/ide/lib/utils/src/serde.rs
+++ b/src/rust/ide/lib/utils/src/serde.rs
@@ -22,24 +22,26 @@ where for<'e> Ret : Default + Deserialize<'e>
 mod tests {
     use super::*;
 
+    use serde::Serialize;
+
     #[test]
     fn deserialize_or_default_attribute_test() {
-        #[derive(Debug, Deserialize, PartialEq, Serialize)]
+        #[derive(Debug,Deserialize,PartialEq,Serialize)]
         // Two structures - same except for `deserialize_or_default` atribute.
         // One fails to deserialize, second one goes through.
         struct Foo {
-            blah: String,
-            boom: Vec<i32>,
+            blah : String,
+            boom : Vec<i32>,
         }
         ;
-        #[derive(Debug, Deserialize, PartialEq, Serialize)]
+        #[derive(Debug,Deserialize,PartialEq,Serialize)]
         struct Bar {
             #[serde(deserialize_with = "deserialize_or_default")]
-            blah: String,
-            boom: Vec<i32>,
+            blah : String,
+            boom : Vec<i32>,
         }
         ;
-        let code = r#"{"blah" : {}, "boom" : [1,2,3] }"#;
+        let code   = r#"{"blah" : {}, "boom" : [1,2,3] }"#;
         let result = serde_json::from_str::<Foo>(code);
         assert!(result.is_err());
 

--- a/src/rust/ide/lib/utils/src/serde.rs
+++ b/src/rust/ide/lib/utils/src/serde.rs
@@ -1,0 +1,49 @@
+//! Module for utilities related to serialization/deserialization using the `serde` library.
+
+#[allow(unused_imports)]
+use crate::prelude::*;
+
+use serde::Deserialize;
+use serde::Deserializer;
+
+/// Try to deserialize value of type `Ret`. In case of any error, it is ignored and the default
+/// value is returned instead.
+pub fn deserialize_or_default<'d,Ret,D>(d:D) -> Result<Ret,D::Error>
+    where for<'e> Ret : Default + Deserialize<'e>
+    ,         D   : Deserializer<'d> {
+    // We first parse as generic JSON value. This is necessary to consume parser input.
+    // If we just tried parsing the desired type directly and ignored error, we would end up with
+    // `trailing characters` error in non-trivial cases.
+    let json_value = serde_json::Value::deserialize(d)?;
+    serde_json::from_value(json_value).or_else(|_error| Ok(Ret::default()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserialize_or_default_attribute_test() {
+        #[derive(Debug, Deserialize, PartialEq, Serialize)]
+        // Two structures - same except for `deserialize_or_default` atribute.
+        // One fails to deserialize, second one goes through.
+        struct Foo {
+            blah: String,
+            boom: Vec<i32>,
+        }
+        ;
+        #[derive(Debug, Deserialize, PartialEq, Serialize)]
+        struct Bar {
+            #[serde(deserialize_with = "deserialize_or_default")]
+            blah: String,
+            boom: Vec<i32>,
+        }
+        ;
+        let code = r#"{"blah" : {}, "boom" : [1,2,3] }"#;
+        let result = serde_json::from_str::<Foo>(code);
+        assert!(result.is_err());
+
+        let deserialized = serde_json::from_str::<Bar>(code).unwrap();
+        assert_eq!(deserialized, Bar { blah: "".into(), boom: vec![1, 2, 3] });
+    }
+}

--- a/src/rust/ide/src/model/module.rs
+++ b/src/rust/ide/src/model/module.rs
@@ -582,7 +582,7 @@ pub mod test {
         assert_eq!(qualified.to_string(), "P.Foo.Bar");
     }
 
-    #[test]
+    #[wasm_bindgen_test]
     fn outdated_metadata_parses() {
         // Metadata here will fail to serialize because `File` is not a valid qualified name.
         // Expected behavior is that invalid metadata parts will be filled with defaults.

--- a/src/rust/ide/src/model/module.rs
+++ b/src/rust/ide/src/model/module.rs
@@ -291,10 +291,11 @@ pub struct Notification {
 // ==============
 
 /// Mapping between ID and metadata.
-#[derive(Debug,Clone,Deserialize,Serialize)]
+#[derive(Clone,Debug,Deserialize,PartialEq,Serialize)]
 pub struct Metadata {
     /// Metadata used within ide.
     #[serde(default="default")]
+    #[serde(deserialize_with="utils::serde::deserialize_or_default")]
     pub ide : IdeMetadata,
     #[serde(flatten)]
     /// Metadata of other users of ParsedSourceFile<Metadata> API.
@@ -316,21 +317,24 @@ impl Default for Metadata {
 }
 
 /// Metadata that belongs to ide.
-#[derive(Debug,Clone,Default,Deserialize,Serialize)]
+#[derive(Clone,Debug,Default,Deserialize,PartialEq,Serialize)]
 pub struct IdeMetadata {
     /// Metadata that belongs to nodes.
+    #[serde(deserialize_with="utils::serde::deserialize_or_default")]
     node : HashMap<ast::Id,NodeMetadata>
 }
 
 /// Metadata of specific node.
-#[derive(Debug,Clone,Default,Serialize,Deserialize)]
+#[derive(Clone,Debug,Default,Deserialize,PartialEq,Serialize)]
 pub struct NodeMetadata {
     /// Position in x,y coordinates.
+    #[serde(deserialize_with="utils::serde::deserialize_or_default")]
     pub position:Option<Position>,
     /// A method which user intends this node to be, e.g. by picking specific suggestion in
     /// Searcher Panel.
     ///
     /// The methods may be defined for different types, so the name alone don't specify them.
+    #[serde(deserialize_with="utils::serde::deserialize_or_default")]
     pub intended_method:Option<MethodId>,
 }
 
@@ -504,6 +508,8 @@ pub type Synchronized = synchronized::Module;
 pub mod test {
     use super::*;
 
+    use std::str::FromStr;
+
     pub fn expect_code(module:&dyn API, expected_code:impl AsRef<str>) {
         let code = module.ast().repr();
         assert_eq!(code,expected_code.as_ref())
@@ -574,5 +580,26 @@ pub mod test {
         let module_path  = Path::from_file_path(file_path).unwrap();
         let qualified    = module_path.qualified_module_name(project_name);
         assert_eq!(qualified.to_string(), "P.Foo.Bar");
+    }
+
+    #[test]
+    fn outdated_metadata_parses() {
+        // Metadata here will fail to serialize because `File` is not a valid qualified name.
+        // Expected behavior is that invalid metadata parts will be filled with defaults.
+        let code = r#"main = 5
+
+
+#### METADATA ####
+[]
+{"ide":{"node":{"bd891b65-4c2f-4c05-bc3b-6077b4417cc1":{"position":{"vector":[-75.5,52]},"intended_method":{"module":"Base.System.File","defined_on_type":"File","name":"read"}}}}}"#;
+        let result = Parser::new_or_panic().parse_with_metadata::<Metadata>(code.into());
+        let file = result.unwrap();
+        assert_eq!(file.ast.repr(), "main = 5");
+        assert_eq!(file.metadata.ide.node.len(), 1);
+        let id = ast::Id::from_str("bd891b65-4c2f-4c05-bc3b-6077b4417cc1").unwrap();
+        let node = file.metadata.ide.node.get(&id).unwrap();
+        assert_eq!(node.position, Some(Position::new(-75.5,52.0)));
+        assert_eq!(node.intended_method, None);
+        assert_eq!(file.metadata.rest, serde_json::Value::Object(default()));
     }
 }


### PR DESCRIPTION
### Pull Request Description
See #1210

### Important Notes
In future more localized metadata error handling should be implemented in the IDE metadata themselves, so only the invalid part is lost. This PR is orthogonal to this — no matter how metadata are broken, IDE should push on.

### Checklist
Please include the following checklist in your PR:

- [x] The `CHANGELOG.md` was updated with the changes introduced in this PR.
- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guide.
- [x] All code has automatic tests where possible.
~~- [ ] All code has been profiled where possible.~~
- [x] All code has been manually tested in the IDE.
~~- [ ] All code has been manually tested in the "debug/interface" scene.~~
- [ ] All code has been manually tested by the PR owner against our [test scenarios](https://docs.google.com/spreadsheets/d/1RatJDM_f9_3bvYhl3Bpq2d8SyKgtVdrV1RkGxPU17c8/edit?ts=5faa7049#gid=0).
- [ ] All code has been manually tested by at least one reviewer against our [test scenarios](https://docs.google.com/spreadsheets/d/1RatJDM_f9_3bvYhl3Bpq2d8SyKgtVdrV1RkGxPU17c8/edit?ts=5faa7049#gid=0).
