### PR TITLE
Do not crash the IDE when logging non-string objects.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@
 - [Fix issue with multiple instances of the IDE running.][1314]. This fixes an
   issue where multiple instances of the IDE (or even other applications) could
   lead to the IDE not working.
+- [Allow JS to log arbitrary objects][1313] Previously using `console.log` in an
+  visualisation or during development woudl crash the IDE. Now it correctly
+  logs the string representation of the object.
 
 #### EnsoGL (rendering engine)
 
@@ -34,6 +37,8 @@ you can find their release notes
 [1209]: https://github.com/enso-org/ide/pull/1209
 [1291]: https://github.com/enso-org/ide/pull/1291
 [1314]: https://github.com/enso-org/ide/pull/1314
+[1313]: https://github.com/enso-org/ide/pull/1313
+
 
 <br/>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,9 @@
 - [Fix issue with multiple instances of the IDE running.][1314] This fixes an
   issue where multiple instances of the IDE (or even other applications) could
   lead to the IDE not working.
-- [Allow JS to log arbitrary objects.][1313] Previously using `console.log` in
-  a visualisation or during development woudl crash the IDE. Now it correctly
-  logs the string representation of the object.
+- [Allow JS to log arbitrary objects.][1313] Previously using `console.log` in a
+  visualisation or during development woudl crash the IDE. Now it correctly logs
+  the string representation of the object.
 - [Disable area selection][1318]. The area selection was visible despite being
   non-functional. To avoid confusion, area selection has been disabled until it
   is [correctly implemented][479].

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 - [Fix issue with multiple instances of the IDE running.][1314]. This fixes an
   issue where multiple instances of the IDE (or even other applications) could
   lead to the IDE not working.
-- [Allow JS to log arbitrary objects][1313] Previously using `console.log` in an
+- [Allow JS to log arbitrary objects.][1313] Previously using `console.log` in an
   visualisation or during development woudl crash the IDE. Now it correctly
   logs the string representation of the object.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,8 @@
 - [Fix issue with multiple instances of the IDE running.][1314] This fixes an
   issue where multiple instances of the IDE (or even other applications) could
   lead to the IDE not working.
-- [Allow JS to log arbitrary objects.][1313] Previously using `console.log` in an
-  visualisation or during development woudl crash the IDE. Now it correctly
+- [Allow JS to log arbitrary objects.][1313] Previously using `console.log` in
+  a visualisation or during development woudl crash the IDE. Now it correctly
   logs the string representation of the object.
 - [Disable area selection][1318]. The area selection was visible despite being
   non-functional. To avoid confusion, area selection has been disabled until it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
   preprocessor. This allows providing visualization with standard library
   functionalities or defining utilities that are shared between multiple
   visualizations.
-- [Fix issue with multiple instances of the IDE running.][1314]. This fixes an
+- [Fix issue with multiple instances of the IDE running.][1314] This fixes an
   issue where multiple instances of the IDE (or even other applications) could
   lead to the IDE not working.
 - [Allow JS to log arbitrary objects.][1313] Previously using `console.log` in an

--- a/src/js/lib/content/src/index.js
+++ b/src/js/lib/content/src/index.js
@@ -250,14 +250,19 @@ class LogRouter {
             this.handleError(...args)
         } else if (name == 'log') {
             let firstArg = args[0]
-            if (firstArg !== undefined && firstArg.startsWith("%c")) {
-                let firstArgBody = firstArg.slice(2);
-                let bodyStartIndex = firstArgBody.indexOf("%c");
-                if (bodyStartIndex !== -1) {
-                    let body = firstArgBody.slice(bodyStartIndex + 3);
-                    let is_error = body.startsWith("[E]");
-                    if (is_error) {
-                        this.handleError(body)
+            if (firstArg !== undefined) {
+                if (!(typeof firstArg === 'string' || firstArg instanceof String)) {
+                    firstArg = firstArg.toString()
+                }
+                if (firstArg.startsWith('%c')) {
+                    let firstArgBody = firstArg.slice(2)
+                    let bodyStartIndex = firstArgBody.indexOf('%c')
+                    if (bodyStartIndex !== -1) {
+                        let body = firstArgBody.slice(bodyStartIndex + 3)
+                        let is_error = body.startsWith('[E]')
+                        if (is_error) {
+                            this.handleError(body)
+                        }
                     }
                 }
             }


### PR DESCRIPTION
### Pull Request Description
Fixes a bug in the log handler that crashes the IDE when it encounters a non-string object.

### Checklist
Please include the following checklist in your PR:

- [ ] ~The `CHANGELOG.md` was updated with the changes introduced in this PR.~
- [ ] ~The documentation has been updated if necessary.~
- [x] All code conforms to the [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guide.
- [ ] ~All code has automatic tests where possible.~
- [ ] ~All code has been profiled where possible.~
- [x] All code has been manually tested in the IDE.
- [x] All code has been manually tested in the "debug/interface" scene.
- [x] All code has been manually tested by the PR owner against our [test scenarios](https://docs.google.com/spreadsheets/d/1RatJDM_f9_3bvYhl3Bpq2d8SyKgtVdrV1RkGxPU17c8/edit?ts=5faa7049#gid=0).
- [ ] All code has been manually tested by at least one reviewer against our [test scenarios](https://docs.google.com/spreadsheets/d/1RatJDM_f9_3bvYhl3Bpq2d8SyKgtVdrV1RkGxPU17c8/edit?ts=5faa7049#gid=0).
