### PR TITLE
Ensure correct port is used to connect to IDE server.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,9 @@
   preprocessor. This allows providing visualization with standard library
   functionalities or defining utilities that are shared between multiple
   visualizations.
-- [Fix issue with multiple instances of the IDE running.][1314]. This fixes an issue where multiple
-  instances of the IDE (or even other applications) could lead to the IDE not working. 
+- [Fix issue with multiple instances of the IDE running.][1314]. This fixes an
+  issue where multiple instances of the IDE (or even other applications) could
+  lead to the IDE not working.
 
 #### EnsoGL (rendering engine)
 
@@ -33,6 +34,7 @@ you can find their release notes
 [1209]: https://github.com/enso-org/ide/pull/1209
 [1291]: https://github.com/enso-org/ide/pull/1291
 [1314]: https://github.com/enso-org/ide/pull/1314
+
 <br/>
 
 # Enso 2.0.0-alpha.2 (2020-03-04)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
   preprocessor. This allows providing visualization with standard library
   functionalities or defining utilities that are shared between multiple
   visualizations.
+- [Ensure correct port is used to connect to IDE server.][1314]. This avoids collisions with other 
+  applications and allows multiple instances of the IDE to run in parallel.
 
 #### EnsoGL (rendering engine)
 
@@ -30,7 +32,7 @@ you can find their release notes
 
 [1209]: https://github.com/enso-org/ide/pull/1209
 [1291]: https://github.com/enso-org/ide/pull/1291
-
+[1314]: https://github.com/enso-org/ide/pull/1314
 <br/>
 
 # Enso 2.0.0-alpha.2 (2020-03-04)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,8 @@
   preprocessor. This allows providing visualization with standard library
   functionalities or defining utilities that are shared between multiple
   visualizations.
-- [Ensure correct port is used to connect to IDE server.][1314]. This avoids collisions with other 
-  applications and allows multiple instances of the IDE to run in parallel.
+- [Fix issue with multiple instances of the IDE running.][1314]. This fixes an issue where multiple
+  instances of the IDE (or even other applications) could lead to the IDE not working. 
 
 #### EnsoGL (rendering engine)
 

--- a/src/js/lib/client/src/index.js
+++ b/src/js/lib/client/src/index.js
@@ -373,8 +373,7 @@ async function main() {
         serverCfg.dir      = root
         serverCfg.fallback = '/assets/index.html'
         server             = await Server.create(serverCfg)
-        const port         = server.port
-        origin             = `http://localhost:${port}`
+        origin             = `http://localhost:${server.port}`
     }
     mainWindow = createWindow()
     mainWindow.on("close", (evt) => {

--- a/src/js/lib/client/src/index.js
+++ b/src/js/lib/client/src/index.js
@@ -363,6 +363,7 @@ let hideInsteadOfQuit = false
 
 let server     = null
 let mainWindow = null
+let origin     = null
 
 async function main() {
     runBackend()
@@ -372,6 +373,8 @@ async function main() {
         serverCfg.dir      = root
         serverCfg.fallback = '/assets/index.html'
         server             = await Server.create(serverCfg)
+        const port         = server.port
+        origin             = `http://localhost:${port}`
     }
     mainWindow = createWindow()
     mainWindow.on("close", (evt) => {
@@ -381,11 +384,6 @@ async function main() {
        }
    })
 }
-
-let port = Server.DEFAULT_PORT
-if      (server)    { port = server.port }
-else if (args.port) { port = args.port }
-let origin = `http://localhost:${port}`
 
 function urlParamsFromObject(obj) {
     let params = []

--- a/src/js/lib/common/src/server.js
+++ b/src/js/lib/common/src/server.js
@@ -10,7 +10,7 @@ import * as portfinder    from 'portfinder'
 // === Port ===
 // ============
 
-export const DEFAULT_PORT = 8080
+const DEFAULT_PORT = 8080
 
 async function findPort(cfg) {
     if (!cfg.port) {


### PR DESCRIPTION
### Pull Request Description
Fixes a bug where the default port was used instead of the correct server port when starting the IDE.

### Checklist
Please include the following checklist in your PR:

- [x] The `CHANGELOG.md` was updated with the changes introduced in this PR.
- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guide.
- [ ] ~All code has automatic tests where possible.~
- [ ] ~All code has been profiled where possible.~
- [x] All code has been manually tested in the IDE.
- [ ] ~All code has been manually tested in the "debug/interface" scene.~
- [x] All code has been manually tested by the PR owner against our [test scenarios](https://docs.google.com/spreadsheets/d/1RatJDM_f9_3bvYhl3Bpq2d8SyKgtVdrV1RkGxPU17c8/edit?ts=5faa7049#gid=0).
- [ ] All code has been manually tested by at least one reviewer against our [test scenarios](https://docs.google.com/spreadsheets/d/1RatJDM_f9_3bvYhl3Bpq2d8SyKgtVdrV1RkGxPU17c8/edit?ts=5faa7049#gid=0).
