### PR TITLE
Avoid truncating pixel ratio for calculating cursor position on canvas.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,10 @@
 - [Fix issue with multiple instances of the IDE running.][1314]. This fixes an
   issue where multiple instances of the IDE (or even other applications) could
   lead to the IDE not working.
-
+- [Fix mouse cursor offset on systems with fractional display scaling][1064].
+  Instead of there being an offset between visible cursor and cursor selection
+  this works now with any display scaling.
+  
 #### EnsoGL (rendering engine)
 
 #### Enso Compiler
@@ -34,6 +37,7 @@ you can find their release notes
 [1209]: https://github.com/enso-org/ide/pull/1209
 [1291]: https://github.com/enso-org/ide/pull/1291
 [1314]: https://github.com/enso-org/ide/pull/1314
+[1064]: https://github.com/enso-org/ide/pull/1064
 
 <br/>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 - [Fix mouse cursor offset on systems with fractional display scaling][1064].
   Instead of there being an offset between visible cursor and cursor selection
   this works now with any display scaling.
-  
+
 #### EnsoGL (rendering engine)
 
 #### Enso Compiler

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,6 @@
   non-functional. To avoid confusion, area selection has been disabled until it
   is [correctly implemented][479].
 
-
 #### EnsoGL (rendering engine)
 
 #### Enso Compiler

--- a/src/rust/ensogl/lib/core/src/display/scene.rs
+++ b/src/rust/ensogl/lib/core/src/display/scene.rs
@@ -335,7 +335,7 @@ impl Mouse {
         let on_move         = mouse_manager.on_move.add(current_js_event.make_event_handler(
             f!([frp,scene_frp,position,last_position] (event:&mouse::OnMove) {
                 let shape       = scene_frp.shape.value();
-                let pixel_ratio = shape.pixel_ratio as i32;
+                let pixel_ratio = shape.pixel_ratio;
                 let screen_x    = event.client_x();
                 let screen_y    = event.client_y();
 
@@ -343,7 +343,7 @@ impl Mouse {
                 let pos_changed = new_pos != last_position.get();
                 if pos_changed {
                     last_position.set(new_pos);
-                    let new_canvas_position = new_pos * pixel_ratio;
+                    let new_canvas_position = new_pos.map(|v| (v as f32 *  pixel_ratio) as i32);
                     position.set(new_canvas_position);
                     let position = Vector2(new_pos.x as f32,new_pos.y as f32) - shape.center();
                     frp.position.emit(position);


### PR DESCRIPTION
### Pull Request Description
Currently, we truncated the pixel ratio for scaling the mouse cursor position to our shapes to an integer value. This is incorrect and leads to offsets when the application is running in an environment with fractional display scaling. 

### Checklist
Please include the following checklist in your PR:

- [x] The `CHANGELOG.md` was updated with the changes introduced in this PR.
- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guide.
- [x] All code has automatic tests where possible.
- [x] All code has been profiled where possible.
- [x] All code has been manually tested in the IDE.
- [x] All code has been manually tested in the "debug/interface" scene.
- [x] All code has been manually tested by the PR owner against our [test scenarios](https://docs.google.com/spreadsheets/d/1RatJDM_f9_3bvYhl3Bpq2d8SyKgtVdrV1RkGxPU17c8/edit?ts=5faa7049#gid=0).
- [ ] All code has been manually tested by at least one reviewer against our [test scenarios](https://docs.google.com/spreadsheets/d/1RatJDM_f9_3bvYhl3Bpq2d8SyKgtVdrV1RkGxPU17c8/edit?ts=5faa7049#gid=0).
