### PR TITLE
Engine updates after adding node: send import first, then the new node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@
 - [Disable area selection][1318]. The area selection was visible despite being
   non-functional. To avoid confusion, area selection has been disabled until it
   is [correctly implemented][479].
+- [Inform the engine about new imports before they are used][#1332]. When the
+  user adds or changes a node through the searcher, the necessary imports are
+  added first, the node content afterwards. This avoids an invalid intermediate
+  state.
 
 #### EnsoGL (rendering engine)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@
 - [Disable area selection][1318]. The area selection was visible despite being
   non-functional. To avoid confusion, area selection has been disabled until it
   is [correctly implemented][479].
-- [Fix error after adding a node][1332]. Sometimes, after picking a suggestion 
+- [Fix error after adding a node][1332]. Sometimes, after picking a suggestion
   the inserted node was annotated with "The name could not be found" error.
 - [Handle syntax errors in custom-defined visualizations][1341]. The IDE is now
   able to run properly, even if some of the custom-defined visualisations inside

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,10 +37,8 @@
 - [Disable area selection][1318]. The area selection was visible despite being
   non-functional. To avoid confusion, area selection has been disabled until it
   is [correctly implemented][479].
-- [Inform the engine about new imports before they are used][#1332]. When the
-  user adds or changes a node through the searcher, the necessary imports are
-  added first, the node content afterwards. This avoids an invalid intermediate
-  state.
+- [Fix error after adding a node][1332]. Sometimes, after picking a suggestion 
+  the inserted node was annotated with "The name could not be found" error.
 
 #### EnsoGL (rendering engine)
 
@@ -58,6 +56,7 @@ you can find their release notes
 [1064]: https://github.com/enso-org/ide/pull/1064
 [1316]: https://github.com/enso-org/ide/pull/1316
 [1318]: https://github.com/enso-org/ide/pull/1318
+[1332]: https://github.com/enso-org/ide/pull/1332
 
 <br/>
 

--- a/src/rust/ide/src/controller/searcher.rs
+++ b/src/rust/ide/src/controller/searcher.rs
@@ -657,6 +657,9 @@ impl Searcher {
         };
         let intended_method = self.intended_method();
 
+        // We add the required imports before we create the node/edit its content. This way, we
+        // avoid an intermediate state where imports would already be in use but not yet available.
+        self.add_required_imports()?;
         let id = match *self.mode {
             Mode::NewNode {position} => {
                 let mut new_node           = NewNodeInfo::new_pushed_back(expression);
@@ -676,7 +679,6 @@ impl Searcher {
                 node_id
             }
         };
-        self.add_required_imports()?;
         Ok(id)
     }
 


### PR DESCRIPTION
### Pull Request Description
<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->
This solves issue #1326. When the user creates a node through the searcher that needs additional imports, those imports should be added before or simultaneously to the node content to avoid an invalid intermediate state. This was done in the wrong order before this commit.

### Important Notes
<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist
Please include the following checklist in your PR:

- [ ] ~The `CHANGELOG.md` was updated with the changes introduced in this PR.~
- [ ] ~The documentation has been updated if necessary.~
- [x] All code conforms to the [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guide.
- [x] All code has automatic tests where possible.
- [ ] ~All code has been profiled where possible.~
- [x] All code has been manually tested in the IDE.
- [ ] ~All code has been manually tested in the "debug/interface" scene.~
- [ ] All code has been manually tested by the PR owner against our [test scenarios](https://docs.google.com/spreadsheets/d/1RatJDM_f9_3bvYhl3Bpq2d8SyKgtVdrV1RkGxPU17c8/edit?ts=5faa7049#gid=0).
- [x] All code has been manually tested by at least one reviewer against our [test scenarios](https://docs.google.com/spreadsheets/d/1RatJDM_f9_3bvYhl3Bpq2d8SyKgtVdrV1RkGxPU17c8/edit?ts=5faa7049#gid=0).
