### PR TITLE
Catch syntax errors in custom visualisations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,9 +40,9 @@
 - [Disable area selection][1318]. The area selection was visible despite being
   non-functional. To avoid confusion, area selection has been disabled until it
   is [correctly implemented][479].
-- [Handle syntax errors in custom-defined visualizations][#1341]. The IDE is
-  now able to run properly, even if some of the custom-defined visualisations
-  inside a project contain syntax errors.
+- [Handle syntax errors in custom-defined visualizations][#1341]. The IDE is now
+  able to run properly, even if some of the custom-defined visualisations inside
+  a project contain syntax errors.
 
 #### EnsoGL (rendering engine)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@
 - [Disable area selection][1318]. The area selection was visible despite being
   non-functional. To avoid confusion, area selection has been disabled until it
   is [correctly implemented][479].
+- [Handle syntax errors in custom-defined visualizations][#1341]. The IDE is
+  now able to run properly, even if some of the custom-defined visualisations
+  inside a project contain syntax errors.
 
 #### EnsoGL (rendering engine)
 

--- a/src/rust/ide/view/graph-editor/src/component/visualization/foreign/java_script/definition.rs
+++ b/src/rust/ide/view/graph-editor/src/component/visualization/foreign/java_script/definition.rs
@@ -5,6 +5,8 @@
 //! * [visualization documentation](https://dev.enso.org/docs/ide/product/visualizations.html).
 // FIXME: Can we simplify the above definition so its more minimal, yet functional?
 
+mod function;
+use function::Function;
 
 use crate::prelude::*;
 
@@ -62,7 +64,7 @@ impl Definition {
         let source       = source.as_ref();
         let source       = source;
         let context      = JsValue::NULL;
-        let function     = js_sys::Function::new_with_args(binding::JS_CLASS_NAME,&source);
+        let function     = Function::new_with_args(binding::JS_CLASS_NAME,&source).map_err(Error::InvalidFunction)?;
         let js_class     = binding::js_class();
         let class        = function.call1(&context,&js_class).map_err(Error::InvalidFunction)?;
 

--- a/src/rust/ide/view/graph-editor/src/component/visualization/foreign/java_script/definition.rs
+++ b/src/rust/ide/view/graph-editor/src/component/visualization/foreign/java_script/definition.rs
@@ -64,7 +64,8 @@ impl Definition {
         let source       = source.as_ref();
         let source       = source;
         let context      = JsValue::NULL;
-        let function     = Function::new_with_args(binding::JS_CLASS_NAME,&source).map_err(Error::InvalidFunction)?;
+        let function     = Function::new_with_args(binding::JS_CLASS_NAME,&source)
+                               .map_err(Error::InvalidFunction)?;
         let js_class     = binding::js_class();
         let class        = function.call1(&context,&js_class).map_err(Error::InvalidFunction)?;
 

--- a/src/rust/ide/view/graph-editor/src/component/visualization/foreign/java_script/definition/function.rs
+++ b/src/rust/ide/view/graph-editor/src/component/visualization/foreign/java_script/definition/function.rs
@@ -1,0 +1,156 @@
+//! The whole content of this file is copied from `js_sys` just to modify `new_with_args and `new_no_args` such that they catch syntax errors.
+//! This is supposed to be temporary solution.
+//! I opened a GitHub issue suggesting that this will be included in wasm-bindgen (https://github.com/rustwasm/wasm-bindgen/issues/2496).
+
+
+use wasm_bindgen::prelude::*;
+use wasm_bindgen::JsCast;
+use js_sys::*;
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(extends = Object, is_type_of = JsValue::is_function)]
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    pub type Function;
+
+    /// The `Function` constructor creates a new `Function` object. Calling the
+    /// constructor directly can create functions dynamically, but suffers from
+    /// security and similar (but far less significant) performance issues
+    /// similar to `eval`. However, unlike `eval`, the `Function` constructor
+    /// allows executing code in the global scope, prompting better programming
+    /// habits and allowing for more efficient code minification.
+    ///
+    /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function)
+    #[wasm_bindgen(constructor, catch)]
+    pub fn new_with_args(args: &str, body: &str) -> Result<Function, JsValue>;
+
+    /// The `Function` constructor creates a new `Function` object. Calling the
+    /// constructor directly can create functions dynamically, but suffers from
+    /// security and similar (but far less significant) performance issues
+    /// similar to `eval`. However, unlike `eval`, the `Function` constructor
+    /// allows executing code in the global scope, prompting better programming
+    /// habits and allowing for more efficient code minification.
+    ///
+    /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function)
+    #[wasm_bindgen(constructor, catch)]
+    pub fn new_no_args(body: &str) -> Result<Function, JsValue>;
+
+    /// The `apply()` method calls a function with a given this value, and arguments provided as an array
+    /// (or an array-like object).
+    ///
+    /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/apply)
+    #[wasm_bindgen(method, catch)]
+    pub fn apply(this: &Function, context: &JsValue, args: &Array) -> Result<JsValue, JsValue>;
+
+    /// The `call()` method calls a function with a given this value and
+    /// arguments provided individually.
+    ///
+    /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/call)
+    #[wasm_bindgen(method, catch, js_name = call)]
+    pub fn call0(this: &Function, context: &JsValue) -> Result<JsValue, JsValue>;
+
+    /// The `call()` method calls a function with a given this value and
+    /// arguments provided individually.
+    ///
+    /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/call)
+    #[wasm_bindgen(method, catch, js_name = call)]
+    pub fn call1(this: &Function, context: &JsValue, arg1: &JsValue) -> Result<JsValue, JsValue>;
+
+    /// The `call()` method calls a function with a given this value and
+    /// arguments provided individually.
+    ///
+    /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/call)
+    #[wasm_bindgen(method, catch, js_name = call)]
+    pub fn call2(
+        this: &Function,
+        context: &JsValue,
+        arg1: &JsValue,
+        arg2: &JsValue,
+    ) -> Result<JsValue, JsValue>;
+
+    /// The `call()` method calls a function with a given this value and
+    /// arguments provided individually.
+    ///
+    /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/call)
+    #[wasm_bindgen(method, catch, js_name = call)]
+    pub fn call3(
+        this: &Function,
+        context: &JsValue,
+        arg1: &JsValue,
+        arg2: &JsValue,
+        arg3: &JsValue,
+    ) -> Result<JsValue, JsValue>;
+
+    /// The `bind()` method creates a new function that, when called, has its this keyword set to the provided value,
+    /// with a given sequence of arguments preceding any provided when the new function is called.
+    ///
+    /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind)
+    #[wasm_bindgen(method, js_name = bind)]
+    pub fn bind(this: &Function, context: &JsValue) -> Function;
+
+    /// The `bind()` method creates a new function that, when called, has its this keyword set to the provided value,
+    /// with a given sequence of arguments preceding any provided when the new function is called.
+    ///
+    /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind)
+    #[wasm_bindgen(method, js_name = bind)]
+    pub fn bind0(this: &Function, context: &JsValue) -> Function;
+
+    /// The `bind()` method creates a new function that, when called, has its this keyword set to the provided value,
+    /// with a given sequence of arguments preceding any provided when the new function is called.
+    ///
+    /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind)
+    #[wasm_bindgen(method, js_name = bind)]
+    pub fn bind1(this: &Function, context: &JsValue, arg1: &JsValue) -> Function;
+
+    /// The `bind()` method creates a new function that, when called, has its this keyword set to the provided value,
+    /// with a given sequence of arguments preceding any provided when the new function is called.
+    ///
+    /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind)
+    #[wasm_bindgen(method, js_name = bind)]
+    pub fn bind2(this: &Function, context: &JsValue, arg1: &JsValue, arg2: &JsValue) -> Function;
+
+    /// The `bind()` method creates a new function that, when called, has its this keyword set to the provided value,
+    /// with a given sequence of arguments preceding any provided when the new function is called.
+    ///
+    /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind)
+    #[wasm_bindgen(method, js_name = bind)]
+    pub fn bind3(
+        this: &Function,
+        context: &JsValue,
+        arg1: &JsValue,
+        arg2: &JsValue,
+        arg3: &JsValue,
+    ) -> Function;
+
+    /// The length property indicates the number of arguments expected by the function.
+    ///
+    /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/length)
+    #[wasm_bindgen(method, getter, structural)]
+    pub fn length(this: &Function) -> u32;
+
+    /// A Function object's read-only name property indicates the function's
+    /// name as specified when it was created or "anonymous" for functions
+    /// created anonymously.
+    ///
+    /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/name)
+    #[wasm_bindgen(method, getter, structural)]
+    pub fn name(this: &Function) -> JsString;
+
+    /// The `toString()` method returns a string representing the source code of the function.
+    ///
+    /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/toString)
+    #[wasm_bindgen(method, js_name = toString)]
+    pub fn to_string(this: &Function) -> JsString;
+}
+
+impl Function {
+    /// Returns the `Function` value of this JS value if it's an instance of a
+    /// function.
+    ///
+    /// If this JS value is not an instance of a function then this returns
+    /// `None`.
+    #[deprecated(note = "recommended to use dyn_ref instead which is now equivalent")]
+    pub fn try_from(val: &JsValue) -> Option<&Function> {
+        val.dyn_ref()
+    }
+}

--- a/src/rust/ide/view/graph-editor/src/component/visualization/foreign/java_script/definition/function.rs
+++ b/src/rust/ide/view/graph-editor/src/component/visualization/foreign/java_script/definition/function.rs
@@ -1,10 +1,11 @@
-//! The whole content of this file is copied from `js_sys` just to modify `new_with_args and `new_no_args` such that they catch syntax errors.
-//! This is supposed to be temporary solution.
-//! I opened a GitHub issue suggesting that this will be included in wasm-bindgen (https://github.com/rustwasm/wasm-bindgen/issues/2496).
-
+//! The whole content of this file consists of parts that were copied from `js_sys` just to modify
+//! `new_with_args` such that it catches syntax errors. This is supposed to be temporary solution.
+//! I opened a GitHub issue suggesting that this will be included in wasm-bindgen
+//! (https://github.com/rustwasm/wasm-bindgen/issues/2496).
+//! A PR with a suggested change to wasm-bindgen can be found here:
+//! https://github.com/rustwasm/wasm-bindgen/pull/2497
 
 use wasm_bindgen::prelude::*;
-use wasm_bindgen::JsCast;
 use js_sys::*;
 
 #[wasm_bindgen]
@@ -19,138 +20,13 @@ extern "C" {
     /// similar to `eval`. However, unlike `eval`, the `Function` constructor
     /// allows executing code in the global scope, prompting better programming
     /// habits and allowing for more efficient code minification.
-    ///
-    /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function)
+    #[allow(unsafe_code)]
     #[wasm_bindgen(constructor, catch)]
     pub fn new_with_args(args: &str, body: &str) -> Result<Function, JsValue>;
 
-    /// The `Function` constructor creates a new `Function` object. Calling the
-    /// constructor directly can create functions dynamically, but suffers from
-    /// security and similar (but far less significant) performance issues
-    /// similar to `eval`. However, unlike `eval`, the `Function` constructor
-    /// allows executing code in the global scope, prompting better programming
-    /// habits and allowing for more efficient code minification.
-    ///
-    /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function)
-    #[wasm_bindgen(constructor, catch)]
-    pub fn new_no_args(body: &str) -> Result<Function, JsValue>;
-
-    /// The `apply()` method calls a function with a given this value, and arguments provided as an array
-    /// (or an array-like object).
-    ///
-    /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/apply)
-    #[wasm_bindgen(method, catch)]
-    pub fn apply(this: &Function, context: &JsValue, args: &Array) -> Result<JsValue, JsValue>;
-
     /// The `call()` method calls a function with a given this value and
     /// arguments provided individually.
-    ///
-    /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/call)
-    #[wasm_bindgen(method, catch, js_name = call)]
-    pub fn call0(this: &Function, context: &JsValue) -> Result<JsValue, JsValue>;
-
-    /// The `call()` method calls a function with a given this value and
-    /// arguments provided individually.
-    ///
-    /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/call)
+    #[allow(unsafe_code)]
     #[wasm_bindgen(method, catch, js_name = call)]
     pub fn call1(this: &Function, context: &JsValue, arg1: &JsValue) -> Result<JsValue, JsValue>;
-
-    /// The `call()` method calls a function with a given this value and
-    /// arguments provided individually.
-    ///
-    /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/call)
-    #[wasm_bindgen(method, catch, js_name = call)]
-    pub fn call2(
-        this: &Function,
-        context: &JsValue,
-        arg1: &JsValue,
-        arg2: &JsValue,
-    ) -> Result<JsValue, JsValue>;
-
-    /// The `call()` method calls a function with a given this value and
-    /// arguments provided individually.
-    ///
-    /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/call)
-    #[wasm_bindgen(method, catch, js_name = call)]
-    pub fn call3(
-        this: &Function,
-        context: &JsValue,
-        arg1: &JsValue,
-        arg2: &JsValue,
-        arg3: &JsValue,
-    ) -> Result<JsValue, JsValue>;
-
-    /// The `bind()` method creates a new function that, when called, has its this keyword set to the provided value,
-    /// with a given sequence of arguments preceding any provided when the new function is called.
-    ///
-    /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind)
-    #[wasm_bindgen(method, js_name = bind)]
-    pub fn bind(this: &Function, context: &JsValue) -> Function;
-
-    /// The `bind()` method creates a new function that, when called, has its this keyword set to the provided value,
-    /// with a given sequence of arguments preceding any provided when the new function is called.
-    ///
-    /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind)
-    #[wasm_bindgen(method, js_name = bind)]
-    pub fn bind0(this: &Function, context: &JsValue) -> Function;
-
-    /// The `bind()` method creates a new function that, when called, has its this keyword set to the provided value,
-    /// with a given sequence of arguments preceding any provided when the new function is called.
-    ///
-    /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind)
-    #[wasm_bindgen(method, js_name = bind)]
-    pub fn bind1(this: &Function, context: &JsValue, arg1: &JsValue) -> Function;
-
-    /// The `bind()` method creates a new function that, when called, has its this keyword set to the provided value,
-    /// with a given sequence of arguments preceding any provided when the new function is called.
-    ///
-    /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind)
-    #[wasm_bindgen(method, js_name = bind)]
-    pub fn bind2(this: &Function, context: &JsValue, arg1: &JsValue, arg2: &JsValue) -> Function;
-
-    /// The `bind()` method creates a new function that, when called, has its this keyword set to the provided value,
-    /// with a given sequence of arguments preceding any provided when the new function is called.
-    ///
-    /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind)
-    #[wasm_bindgen(method, js_name = bind)]
-    pub fn bind3(
-        this: &Function,
-        context: &JsValue,
-        arg1: &JsValue,
-        arg2: &JsValue,
-        arg3: &JsValue,
-    ) -> Function;
-
-    /// The length property indicates the number of arguments expected by the function.
-    ///
-    /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/length)
-    #[wasm_bindgen(method, getter, structural)]
-    pub fn length(this: &Function) -> u32;
-
-    /// A Function object's read-only name property indicates the function's
-    /// name as specified when it was created or "anonymous" for functions
-    /// created anonymously.
-    ///
-    /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/name)
-    #[wasm_bindgen(method, getter, structural)]
-    pub fn name(this: &Function) -> JsString;
-
-    /// The `toString()` method returns a string representing the source code of the function.
-    ///
-    /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/toString)
-    #[wasm_bindgen(method, js_name = toString)]
-    pub fn to_string(this: &Function) -> JsString;
-}
-
-impl Function {
-    /// Returns the `Function` value of this JS value if it's an instance of a
-    /// function.
-    ///
-    /// If this JS value is not an instance of a function then this returns
-    /// `None`.
-    #[deprecated(note = "recommended to use dyn_ref instead which is now equivalent")]
-    pub fn try_from(val: &JsValue) -> Option<&Function> {
-        val.dyn_ref()
-    }
 }


### PR DESCRIPTION
### Pull Request Description
<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->
This is a potential solution to #1310.

Syntax errors in custom visualisations caused panics during IDE startup. Now they are caught and handled like errors during execution of the visualisation code, which means that we write a log message to the console.

### Important Notes
<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

The wasm-bindgen API that we used to parse visualisation code from JS, does not allow to handle syntax errors, it always panics on those. I filed an issue at their GitHub repo, suggesting that they allow error handling. As a temporary fix, this PR includes a copy of their relevant code with the necessary changes. We could merge this now or wait to see if they react to the issue and provide the possibility for a cleaner solution.

With this PR, syntax errors in visualisations will only be logged to the console, which means that they stay invisible to normal users. In the long term, they should be reported on the GUI.

### Checklist
Please include the following checklist in your PR:

- [x] The `CHANGELOG.md` was updated with the changes introduced in this PR.
- [ ] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guide.
- [ ] All code has automatic tests where possible.
- [ ] All code has been profiled where possible.
- [x] All code has been manually tested in the IDE.
- [ ] All code has been manually tested in the "debug/interface" scene.
- [ ] All code has been manually tested by the PR owner against our [test scenarios](https://docs.google.com/spreadsheets/d/1RatJDM_f9_3bvYhl3Bpq2d8SyKgtVdrV1RkGxPU17c8/edit?ts=5faa7049#gid=0).
- [ ] All code has been manually tested by at least one reviewer against our [test scenarios](https://docs.google.com/spreadsheets/d/1RatJDM_f9_3bvYhl3Bpq2d8SyKgtVdrV1RkGxPU17c8/edit?ts=5faa7049#gid=0).
