### PR TITLE
Fix pasting multiline code in single-lined text area

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,9 +43,9 @@
 - [Handle syntax errors in custom-defined visualizations][#1341]. The IDE is now
   able to run properly, even if some of the custom-defined visualisations inside
   a project contain syntax errors.
-- [Fix pasting multiline code in nodes][1348]. Since nodes contain only a
-  single line, the first copied line will be inserted and all additional lines
-  will be ignored.
+- [Fix pasting multiline code in nodes][1348]. Since nodes contain only a single
+  line, the first copied line will be inserted and all additional lines will be
+  ignored.
 
 #### EnsoGL (rendering engine)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,8 +43,8 @@
 - [Handle syntax errors in custom-defined visualizations][#1341]. The IDE is now
   able to run properly, even if some of the custom-defined visualisations inside
   a project contain syntax errors.
-- [Fix pasting multiline code in nodes][1348]. Since nodes contain only a single
-  line, the first copied line will be inserted and all additional lines will be
+- [Fix issues with pasting multi-line text into single-line text fields][1348].
+  The first copied line will be inserted and all additional lines will be
   ignored.
 
 #### EnsoGL (rendering engine)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@
 - [Disable area selection][1318]. The area selection was visible despite being
   non-functional. To avoid confusion, area selection has been disabled until it
   is [correctly implemented][479].
+- [Fix pasting multiline code in nodes][1348]. Since nodes contain only a
+  single line, the first copied line will be inserted and all additional lines
+  will be ignored.
 
 #### EnsoGL (rendering engine)
 

--- a/src/rust/ensogl/lib/text/src/component/area.rs
+++ b/src/rust/ensogl/lib/text/src/component/area.rs
@@ -569,7 +569,7 @@ impl Area {
             eval_ sels_cut (m.buffer.frp.delete_left());
 
             eval_ input.paste (m.paste());
-            eval input.paste_string([m](s) m.paste_string(s));
+            eval input.paste_string((s) m.paste_string(s));
 
 
             eval_ m.buffer.frp.text_change (m.redraw(true));

--- a/src/rust/ensogl/lib/text/src/component/area.rs
+++ b/src/rust/ensogl/lib/text/src/component/area.rs
@@ -569,7 +569,16 @@ impl Area {
             eval_ sels_cut (m.buffer.frp.delete_left());
 
             eval_ input.paste (m.paste());
-            eval input.paste_string ((s) m.buffer.frp.paste(m.decode_paste(s)));
+            eval input.paste_string([m](s) {
+                let mut fragments = m.decode_paste(s);
+                if m.single_line.get() {
+                    fragments = fragments
+                        .iter()
+                        .map(|fragment| fragment.lines().next().unwrap_or("").to_string())
+                        .collect();
+                }
+                m.buffer.frp.paste(fragments);
+            });
 
 
             eval_ m.buffer.frp.text_change (m.redraw(true));

--- a/src/rust/ensogl/lib/text/src/component/area.rs
+++ b/src/rust/ensogl/lib/text/src/component/area.rs
@@ -953,7 +953,13 @@ impl AreaModel {
         let paste_string = self.frp_endpoints.input.paste_string.clone_ref();
         clipboard::read_text(move |t| paste_string.emit(t));
     }
-    
+
+    /// Paste new text in the place of current selections / cursors. In case of pasting multiple
+    /// chunks (e.g. after copying multiple selections), the chunks will be pasted into subsequent
+    /// selections. In case there are more chunks than selections, end chunks will be dropped. In
+    /// case there is more selections than chunks, end selections will be replaced with empty
+    /// strings. I `self.single_line` is set to true then each chunk will be truncated to its first
+    /// line.
     fn paste_string(&self, s: &str) {
         let mut chunks = self.decode_paste(s);
         if self.single_line.get() {


### PR DESCRIPTION

### Pull Request Description
<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->
When pasting multiline code in a single-lined text area, only the first line will be inserted.

This fixes issue #1336.

### Important Notes
<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

This seems to duplicate some logic from `key_to_string` on text areas, which also handles newlines specially in single-line situations. Maybe they should be combined in some way?

### Checklist
Please include the following checklist in your PR:

- [x] The `CHANGELOG.md` was updated with the changes introduced in this PR.
- [ ] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guide.
- [ ] All code has automatic tests where possible.
- [ ] All code has been profiled where possible.
- [x] All code has been manually tested in the IDE.
- [ ] All code has been manually tested in the "debug/interface" scene.
- [ ] All code has been manually tested by the PR owner against our [test scenarios](https://docs.google.com/spreadsheets/d/1RatJDM_f9_3bvYhl3Bpq2d8SyKgtVdrV1RkGxPU17c8/edit?ts=5faa7049#gid=0).
- [ ] All code has been manually tested by at least one reviewer against our [test scenarios](https://docs.google.com/spreadsheets/d/1RatJDM_f9_3bvYhl3Bpq2d8SyKgtVdrV1RkGxPU17c8/edit?ts=5faa7049#gid=0).
