### PR TITLE
Run all backend processed even if the IDE package is run with --no-window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,10 @@
   a project contain syntax errors.
 - [Users can opt out of anonymous data gathering.][1328] This can be done with
   the `--no-data-gathering` command-line flag during the startup of the IDE.
+- [You can now start the IDE service without window again.][1353] The command
+  line arguyment `--no-window` now starts all the required backend services
+  again, and prints the port on the command line, allowing you to open the IDE
+  with a browser of your choice.
 
 #### EnsoGL (rendering engine)
 
@@ -62,6 +66,7 @@ you can find their release notes
 [1064]: https://github.com/enso-org/ide/pull/1064
 [1316]: https://github.com/enso-org/ide/pull/1316
 [1318]: https://github.com/enso-org/ide/pull/1318
+[1353]: https://github.com/enso-org/ide/pull/1353
 
 <br/>
 

--- a/src/js/lib/client/src/index.js
+++ b/src/js/lib/client/src/index.js
@@ -369,9 +369,9 @@ let server     = null
 let mainWindow = null
 let origin     = null
 
-async function main() {
+async function main(args) {
     runBackend()
-    console.log("Starting the IDE.")
+    console.log("Starting the IDE service.")
     if(args.server !== false) {
         let serverCfg      = Object.assign({},args)
         serverCfg.dir      = root
@@ -379,13 +379,16 @@ async function main() {
         server             = await Server.create(serverCfg)
         origin             = `http://localhost:${server.port}`
     }
-    mainWindow = createWindow()
-    mainWindow.on("close", (evt) => {
-       if (hideInsteadOfQuit) {
-           evt.preventDefault()
-           mainWindow.hide()
-       }
-   })
+    if(args.window !== false) {
+        console.log("Starting the IDE client.")
+        mainWindow = createWindow()
+        mainWindow.on("close", (evt) => {
+            if (hideInsteadOfQuit) {
+                evt.preventDefault()
+                mainWindow.hide()
+            }
+        })
+    }
 }
 
 function urlParamsFromObject(obj) {
@@ -515,9 +518,7 @@ Electron.app.on('ready', () => {
     } else if (args.info) {
         printDebugInfo()
     } else {
-        if(args.window !== false) {
-            main()
-        }
+        main(args)
     }
 })
 


### PR DESCRIPTION
### Pull Request Description
Previously ` --no-window` would skip the whole IDE main function. This is no more localized: we run the language server and IDE service, but skip opening a window. 

### Checklist
Please include the following checklist in your PR:

- [x] The `CHANGELOG.md` was updated with the changes introduced in this PR.
- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guide.
- [ ] ~All code has automatic tests where possible.~
- [x] All code has been profiled where possible.
- [x] All code has been manually tested in the IDE.
- [ ] ~All code has been manually tested in the "debug/interface" scene.~
- [ ] ~All code has been manually tested by the PR owner against our [test scenarios](https://docs.google.com/spreadsheets/d/1RatJDM_f9_3bvYhl3Bpq2d8SyKgtVdrV1RkGxPU17c8/edit?ts=5faa7049#gid=0).~
- [ ] ~All code has been manually tested by at least one reviewer against our [test scenarios](https://docs.google.com/spreadsheets/d/1RatJDM_f9_3bvYhl3Bpq2d8SyKgtVdrV1RkGxPU17c8/edit?ts=5faa7049#gid=0).~
