### PR TITLE
Fix strange this argument applying in searcher.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,10 @@
   with a browser of your choice.
 - [JS visualizations have consistent gestures with the IDE][1291]. Panning and
   zooming now works just as expected on trackpad and mouse.
+- [Fix applying selected node output to the expression of new node][1385]. For
+  example, having selected node with Table output and adding a new node with
+  expression `at "x" == "y"` the selected node was applied to the right side of
+  `==`: `at "x" == operator1."y"` instead of `operator1.at "x" == "y"`.
 
 #### EnsoGL (rendering engine)
 
@@ -84,6 +88,7 @@ you can find their release notes
 [1341]: https://github.com/enso-org/ide/pull/1341
 [1348]: https://github.com/enso-org/ide/pull/1348
 [1353]: https://github.com/enso-org/ide/pull/1353
+[1385]: https://github.com/enso-org/ide/pull/1385
 
 <br/>
 

--- a/src/rust/ide/src/controller/searcher.rs
+++ b/src/rust/ide/src/controller/searcher.rs
@@ -965,13 +965,13 @@ fn apply_this_argument(this_var:&str, ast:&Ast) -> Ast {
             opr: opr.into()
         };
         Ast::new(shape,None)
-    } else if let Some(mut infix_chain) = ast::opr::Chain::try_new(ast) {
-        if let Some(ref mut target) = &mut infix_chain.target {
-             target.arg = apply_this_argument(this_var,&target.arg);
+    } else if let Some(mut infix) = ast::opr::GeneralizedInfix::try_new(ast) {
+        if let Some(ref mut larg) = &mut infix.left {
+             larg.arg = apply_this_argument(this_var,&larg.arg);
         } else {
-            infix_chain.target = Some(ast::opr::ArgWithOffset {arg:Ast::var(this_var), offset:1});
+            infix.left = Some(ast::opr::ArgWithOffset {arg:Ast::var(this_var), offset:1});
         }
-        infix_chain.into_ast()
+        infix.into_ast()
     } else if let Some(mut prefix_chain) = ast::prefix::Chain::from_ast(ast) {
         prefix_chain.func = apply_this_argument(this_var, &prefix_chain.func);
         prefix_chain.into_ast()
@@ -1537,6 +1537,7 @@ pub mod test {
             , Case::new("+ 2 - 3", "foo + 2 - 3")
             , Case::new("+ bar baz", "foo + bar baz")
             , Case::new("map x-> x.characters.length", "foo.map x-> x.characters.length")
+            , Case::new("at 3 == y", "foo.at 3 == y")
             ];
 
         for case in &cases { case.run(); }


### PR DESCRIPTION
### Pull Request Description
Before we applied this argument to the operator target. But best UX is when the argument is applied to the left side of the operand.


### Checklist
Please include the following checklist in your PR:

- [ ] The `CHANGELOG.md` was updated with the changes introduced in this PR.
- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guide.
- [x] All code has automatic tests where possible.
- [ ] ~~All code has been profiled where possible.~~
- [x] All code has been manually tested in the IDE.
- [ ] ~~All code has been manually tested in the "debug/interface" scene.~~
- [ ] All code has been manually tested by the PR owner against our [test scenarios](https://docs.google.com/spreadsheets/d/1RatJDM_f9_3bvYhl3Bpq2d8SyKgtVdrV1RkGxPU17c8/edit?ts=5faa7049#gid=0).
- [ ] All code has been manually tested by at least one reviewer against our [test scenarios](https://docs.google.com/spreadsheets/d/1RatJDM_f9_3bvYhl3Bpq2d8SyKgtVdrV1RkGxPU17c8/edit?ts=5faa7049#gid=0).
