### PR TITLE
Hotfix: GeoMap not showing up in list

### DIFF
--- a/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/geoMap.js
+++ b/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/geoMap.js
@@ -92,6 +92,8 @@ const makeId = makeGenerator()
  * }
  *
  * Can also consume a dataframe that has the columns `latitude`, `longitude` and optionally `label`.
+ *
+ * TODO: Make 2-finger panning behave like in IDE, and RMB zooming. [#1368]
  */
 class GeoMapVisualization extends Visualization {
     static inputType = 'Any'

--- a/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/geoMap.js
+++ b/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/geoMap.js
@@ -65,24 +65,6 @@ function makeGenerator() {
 
 const makeId = makeGenerator()
 
-/**
- * Custom Map Controller, enabling us to redefine mouse gestures.
- * TODO: Make 2-finger panning behave like in IDE, and RMB zooming. [#1368]
- */
-class MapController extends deck.MapController {
-    handleEvent(event) {
-        if (event.type === 'wheel') {
-            if (!event.srcEvent.ctrlKey) {
-                super.handleEvent(event)
-            } else {
-                super.handleEvent(event)
-            }
-        } else {
-            super.handleEvent(event)
-        }
-    }
-}
-
 // ============================
 // === MapViewVisualization ===
 // ============================
@@ -195,7 +177,7 @@ class GeoMapVisualization extends Visualization {
         this.zoom = ok(data.zoom) ? data.zoom : DEFAULT_MAP_ZOOM
         this.mapStyle = ok(data.mapStyle) ? data.mapStyle : this.defaultMapStyle
         this.pitch = ok(data.pitch) ? data.pitch : 0
-        this.controller = ok(data.controller) ? data.controller : { type: MapController }
+        this.controller = ok(data.controller) ? data.controller : true
         this.showingLabels = ok(data.showingLabels) ? data.showingLabels : false
         return true
     }

--- a/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/sql.js
+++ b/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/sql.js
@@ -101,7 +101,7 @@ class SqlVisualization extends Visualization {
 
         let visHtml = visualizationStyle
         if (parsedData.error !== undefined) {
-            visHtml +=  '<pre class="sql">' + parsedData.error + '</pre>'
+            visHtml += '<pre class="sql">' + parsedData.error + '</pre>'
         } else {
             const params = parsedData.interpolations.map(param =>
                 renderInterpolationParameter(this.theme, param)

--- a/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/sql.js
+++ b/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/sql.js
@@ -101,7 +101,7 @@ class SqlVisualization extends Visualization {
 
         let visHtml = visualizationStyle
         if (parsedData.error !== undefined) {
-            visHtml += parsedData.error
+            visHtml +=  '<pre class="sql">' + parsedData.error + '</pre>'
         } else {
             const params = parsedData.interpolations.map(param =>
                 renderInterpolationParameter(this.theme, param)


### PR DESCRIPTION
### Pull Request Description
Because of trying to fix 2-finger-pan in GeoMap I've added a stub MapController. As it turned out, this map controller tried to load before deck-gl got loaded, hence making `deck` word undefined. I've removed it as it is not necessary now.
The thing is that i havent noticed it because when You click cmd/ctrl+I vis list refreshes, and then the deck is already loaded so geomap works again and shows up on list.

Here's the screen that it in fact works:

<img width="354" alt="Zrzut ekranu 2021-03-25 o 21 02 37" src="https://user-images.githubusercontent.com/26655166/112536199-72cf9f00-8dad-11eb-8d24-21c75bafea0d.png">

### Important Notes
<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist
Please include the following checklist in your PR:

- [ ] The `CHANGELOG.md` was updated with the changes introduced in this PR.
- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guide.
- [x] All code has automatic tests where possible.
- [x] All code has been profiled where possible.
- [x] All code has been manually tested in the IDE.
- [x] All code has been manually tested in the "debug/interface" scene.
- [x] All code has been manually tested by the PR owner against our [test scenarios](https://docs.google.com/spreadsheets/d/1RatJDM_f9_3bvYhl3Bpq2d8SyKgtVdrV1RkGxPU17c8/edit?ts=5faa7049#gid=0).
- [ ] All code has been manually tested by at least one reviewer against our [test scenarios](https://docs.google.com/spreadsheets/d/1RatJDM_f9_3bvYhl3Bpq2d8SyKgtVdrV1RkGxPU17c8/edit?ts=5faa7049#gid=0).
