### PR TITLE
Revert "`onHide` callback for Visualizations"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,9 +31,6 @@
   `Column` datatypes are properly visualized. Scatter Plot can display points of
   different color, shape and size, all as defined by the data within the
   `Table`.
-- [`onHide callback for visualizations][1383]. JavaScript visualizations can now
-  implement a method `onHide()` that will be called whenever the visualization
-  is hidden or closed on screen.
 
 <br/>![Bug Fixes](/docs/assets/tags/bug_fixes.svg)
 

--- a/docs/product/visualizations.md
+++ b/docs/product/visualizations.md
@@ -275,11 +275,6 @@ In particular:
   from the server. Note that the visualization will receive the "full data" if
   you are not using the `setPreprocessor` method.
 
-- ### [Optional] Function `onHide`
-
-  The `onHide()` method is called whenever the visualization is hidden or closed
-  on screen.
-
 - ### [Optional] Function `setSize`
 
   The `setSize(size)` method is called on every size change of the

--- a/src/rust/ide/view/graph-editor/src/component/visualization/foreign/java_script/definition.rs
+++ b/src/rust/ide/view/graph-editor/src/component/visualization/foreign/java_script/definition.rs
@@ -41,7 +41,6 @@ pub mod field {
 pub mod method {
     pub const ON_DATA_RECEIVED : &str = "onDataReceived";
     pub const SET_SIZE         : &str = "setSize";
-    pub const ON_HIDE          : &str = "onHide";
 }
 
 

--- a/src/rust/ide/view/graph-editor/src/component/visualization/foreign/java_script/instance.rs
+++ b/src/rust/ide/view/graph-editor/src/component/visualization/foreign/java_script/instance.rs
@@ -89,7 +89,6 @@ type PreprocessorCallbackCell = Rc<RefCell<Option<Box<dyn PreprocessorCallback>>
 #[allow(missing_docs)]
 pub struct InstanceModel {
     pub root_node           : DomSymbol,
-        display_object      : display::object::Instance,
     pub logger              : Logger,
         on_data_received    : Rc<Option<js_sys::Function>>,
         set_size            : Rc<Option<js_sys::Function>>,
@@ -120,6 +119,7 @@ impl InstanceModel {
         let bg_blue  = bg_color.blue*255.0;
         let bg_hex   = format!("rgba({},{},{},{})",bg_red,bg_green,bg_blue,bg_color.alpha);
         root_node.dom().set_style_or_warn("background",bg_hex,logger);
+
         Ok(root_node)
     }
 
@@ -169,17 +169,8 @@ impl InstanceModel {
         let set_size                      = Rc::new(set_size);
         let object                        = Rc::new(object);
         let scene                         = scene.clone_ref();
-        let display_object                = display::object::Instance::new(Logger::new(""));
-        display_object.add_child(root_node.display_object());
-        let on_hide                       = get_method(&object.as_ref(), method::ON_HIDE).ok();
-        if let Some(f) = on_hide {
-            display_object.set_on_hide(move |_| {
-                let context = &JsValue::NULL;
-                let _       = f.call0(context);
-            });
-        }
         Ok(InstanceModel{object,on_data_received,set_size,root_node,logger,preprocessor_change,
-                         display_object,scene})
+                         scene})
     }
 
     /// Hooks the root node into the given scene.
@@ -302,7 +293,7 @@ impl From<Instance> for visualization::Instance {
 
 impl display::Object for Instance {
     fn display_object(&self) -> &display::object::Instance {
-        &self.model.display_object
+        &self.model.root_node.display_object()
     }
 }
 


### PR DESCRIPTION
Reverts enso-org/ide#1383 . The implementation is making objects live too long and it introduces several regressions. The logic in the display object hierarchy was correct before this PR.