### PR TITLE
Fix Backend Dying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,8 @@
   when the mouse events are passed to the visualization.
 - [Fixed an issue when projects containing certain language constructs failed to
   load.][1413]
+- [Fixed a case where IDE could lose connection to the backend after some
+  time.][1428]
 
 #### EnsoGL (rendering engine)
 
@@ -147,6 +149,7 @@ you can find their release notes
 [1412]: https://github.com/enso-org/ide/pull/1412
 [1419]: https://github.com/enso-org/ide/pull/1419
 [1413]: https://github.com/enso-org/ide/pull/1413
+[1428]: https://github.com/enso-org/ide/pull/1428
 
 <br/>
 

--- a/src/js/lib/client/src/index.js
+++ b/src/js/lib/client/src/index.js
@@ -342,11 +342,31 @@ function projectManagerPath() {
     return binPath
 }
 
+/**
+ * Executes the Project Manager with given arguments.
+ * 
+ * Note that this function captures all the Project Manager output into a fixed
+ * size buffer. If too much output is produced, it will fail and Project 
+ * Manager process will prematurely close.
+ * 
+ * @param {string[]} args Project Manager command line arguments.
+ * @returns Promise with captured standard output and error contents.
+ */
 async function execProjectManager(args) {
     let binPath = projectManagerPath()
     return await execFile(binPath,args).catch(function(err) {throw err})
 }
 
+/**
+ * Spawn process with Project Manager,
+ * 
+ * The standard output and error handles will be inherited, i.e. will be
+ * redirected to the electron's app output and error handles. Input is piped
+ * to this process, so it will not be closed, until this process finished.
+ * 
+ * @param {string[]} args 
+ * @returns Handle to the spawned process.
+ */
 function spawnProjectManager(args) { 
     let binPath = projectManagerPath()
     let stdin = 'pipe'


### PR DESCRIPTION
### Pull Request Description
Previously Project Manager was spawned using `execFile` function that captures spawned process outputs and puts them in limited size buffers. This caused backend to be killed after the limit has been exceeded.

### Important Notes
<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist
Please include the following checklist in your PR:

- [x] The `CHANGELOG.md` was updated with the changes introduced in this PR.
- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guide.
~- [ ] All code has automatic tests where possible.~
~- [ ] All code has been profiled where possible.~
- [x] All code has been manually tested in the IDE.
~- [ ] All code has been manually tested in the "debug/interface" scene.~
- [x] All code has been manually tested by the PR owner against our [test scenarios](https://docs.google.com/spreadsheets/d/1RatJDM_f9_3bvYhl3Bpq2d8SyKgtVdrV1RkGxPU17c8/edit?ts=5faa7049#gid=0).
- [ ] All code has been manually tested by at least one reviewer against our [test scenarios](https://docs.google.com/spreadsheets/d/1RatJDM_f9_3bvYhl3Bpq2d8SyKgtVdrV1RkGxPU17c8/edit?ts=5faa7049#gid=0).
