### PR TITLE
Suppressing spurious type updates.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,8 @@
   load.][1413]
 - [Fixed a case where IDE could lose connection to the backend after some
   time.][1428]
+- [Improved performance of the graph editor, particularly when opening a project
+  for a first time.][1445]
 
 #### EnsoGL (rendering engine)
 
@@ -162,6 +164,7 @@ you can find their release notes
 [1428]: https://github.com/enso-org/ide/pull/1428
 [1438]: https://github.com/enso-org/ide/pull/1438
 [1367]: https://github.com/enso-org/ide/pull/1367
+[1445]: https://github.com/enso-org/ide/pull/1445
 
 <br/>
 

--- a/src/rust/ide/src/ide/integration.rs
+++ b/src/rust/ide/src/ide/integration.rs
@@ -659,12 +659,12 @@ impl Model {
     /// graph editor view.
     ///
     /// The computed value information includes the expression type and the target method pointer.
-    fn refresh_computed_info(&self, id:ExpressionId, force_refresh:bool) {
+    fn refresh_computed_info(&self, id:ExpressionId, force_type_info_refresh:bool) {
         let info     = self.lookup_computed_info(&id);
         let info     = info.as_ref();
         let typename = info.and_then(|info| info.typename.clone().map(graph_editor::Type));
         if let Some(node_id) = self.node_view_by_expression.borrow().get(&id).cloned() {
-            self.set_type(node_id,id,typename,force_refresh);
+            self.set_type(node_id,id,typename, force_type_info_refresh);
             let method_pointer = info.and_then(|info| {
                 info.method_call.and_then(|entry_id| {
                     let opt_method = self.project.suggestion_db().lookup_method_ptr(entry_id).ok();

--- a/src/rust/ide/view/graph-editor/src/component/node/input/port.rs
+++ b/src/rust/ide/view/graph-editor/src/component/node/input/port.rs
@@ -132,7 +132,7 @@ ensogl::define_endpoints! {
         set_hover            (bool),
         set_connected        (bool,Option<Type>),
         set_parent_connected (bool),
-        set_definition_type   (Option<Type>),
+        set_definition_type  (Option<Type>),
         set_usage_type       (Option<Type>),
     }
 

--- a/src/rust/ide/view/graph-editor/src/component/type_coloring.rs
+++ b/src/rust/ide/view/graph-editor/src/component/type_coloring.rs
@@ -42,12 +42,8 @@ use std::hash::Hasher;
 /// parametrization, other mechanisms should be used. For example, `Point Float` and `Point Number`
 /// should have similar colors, completely distinct from their parameter types.
 pub fn compute(tp:&Type, styles:&StyleWatch) -> color::Lcha {
-    // FIXME: Left for performance debug purposes. See: https://github.com/enso-org/ide/issues/952
-    // println!("Type coloring for: '{}",tp.as_str());
     let types_path = theme::code::types::overriden::HERE.path();
     let type_path  = types_path.into_subs(tp.as_str().split('.'));
-    // FIXME: Left for performance debug purposes. See: https://github.com/enso-org/ide/issues/952
-    // println!("Path: {:?}",type_path);
     let hue = styles.get(type_path.sub("hue")).number_or_else(|| auto_hue(tp,styles));
     let lightness = styles.get(type_path.sub("lightness")).number_or_else(||
         styles.get_number_or(theme::code::types::lightness,0.85));

--- a/src/rust/ide/view/graph-editor/src/lib.rs
+++ b/src/rust/ide/view/graph-editor/src/lib.rs
@@ -3040,5 +3040,3 @@ impl display::Object for GraphEditor {
         self.model.display_object()
     }
 }
-
-


### PR DESCRIPTION
### Pull Request Description
Graph editor integration will suppress spurious set_type calls.
However, types will be always refreshed as part of node expression refresh.

### Important Notes
<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist
Please include the following checklist in your PR:

- [x] The `CHANGELOG.md` was updated with the changes introduced in this PR.
- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guide.
- [x] All code has automatic tests where possible.
- [x] All code has been profiled where possible.
- [x] All code has been manually tested in the IDE.
~- [ ] All code has been manually tested in the "debug/interface" scene.~
- [x] All code has been manually tested by the PR owner against our [test scenarios](https://docs.google.com/spreadsheets/d/1RatJDM_f9_3bvYhl3Bpq2d8SyKgtVdrV1RkGxPU17c8/edit?ts=5faa7049#gid=0).
- [ ] All code has been manually tested by at least one reviewer against our [test scenarios](https://docs.google.com/spreadsheets/d/1RatJDM_f9_3bvYhl3Bpq2d8SyKgtVdrV1RkGxPU17c8/edit?ts=5faa7049#gid=0).
