### PR TITLE
Add background to breadcrumbs and status bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@
   `Table`.
 - [Many small visual improvements.][1419] See the source issue for more details.
 - [Added Heatmap visualization.][1438]
+- [Add backgrounds to the project name and status bar][1447]. Both now have a
+  background with drop shadow for better readability.
 
 <br/>![Bug Fixes](/docs/assets/tags/bug_fixes.svg)
 

--- a/src/rust/ensogl/lib/components/src/shadow.rs
+++ b/src/rust/ensogl/lib/components/src/shadow.rs
@@ -2,17 +2,43 @@
 use crate::prelude::*;
 
 use ensogl_core::data::color;
-use ensogl_core::display::DomSymbol;
+use ensogl_core::display::{DomSymbol, style};
 use ensogl_core::display::shape::*;
 use ensogl_core::display::shape::AnyShape;
 use ensogl_core::system::web::StyleSetter;
 use ensogl_theme as theme;
 
 
+/// Defines the apearance of a shadow
+#[derive(Debug,Copy,Clone)]
+pub struct Parameters {
+    base_color : color::Rgba,
+    fading     : color::Rgba,
+    size       : f32,
+    spread     : f32,
+    exponent   : f32,
+    offset_x   : f32,
+    offset_y   : f32
+}
+
+/// Loads shadow parameters from the given style, at the given path. The structure of the style
+/// definition should be analogous to that at `ensogl_theme::shadow`.
+pub fn parameters_from_style_path(style:&StyleWatch,path:impl Into<style::Path>) -> Parameters {
+    let path: style::Path = path.into();
+    Parameters {
+        base_color: style.get_color(&path),
+        fading: style.get_color(&path.sub("fading")),
+        size: style.get_number(&path.sub("size")),
+        spread: style.get_number(&path.sub("spread")),
+        exponent: style.get_number(&path.sub("exponent")),
+        offset_x: style.get_number(&path.sub("offset_x")),
+        offset_y: style.get_number(&path.sub("offset_y"))
+    }
+}
 
 /// Return a shadow for the given shape. Exact appearance will depends on the theme parameters.
 pub fn from_shape(base_shape:AnyShape, style:&StyleWatch) -> AnyShape {
-    let alpha         = Var::<f32>::from(1.0);
+    let alpha = Var::<f32>::from(1.0);
     from_shape_with_alpha(base_shape,&alpha,style)
 }
 
@@ -20,29 +46,35 @@ pub fn from_shape(base_shape:AnyShape, style:&StyleWatch) -> AnyShape {
 /// The color will be multiplied with the given alpha value, which is useful for fade-in/out
 /// animations.
 pub fn from_shape_with_alpha(base_shape:AnyShape,alpha:&Var<f32>,style:&StyleWatch) -> AnyShape {
-    let shadow_size   = style.get_number(theme::shadow::size);
-    let shadow_spread = style.get_number(theme::shadow::spread);
-    let shadow_off_x  = style.get_number(theme::shadow::offset_x).px();
-    let shadow_off_y  = style.get_number(theme::shadow::offset_y).px();
+    let parameters = parameters_from_style_path(style, theme::shadow);
+    from_shape_with_parameters_and_alpha(base_shape,parameters,alpha)
+}
 
-    let shadow_grow   = Var::<f32>::from(shadow_size);
-    let shadow        = base_shape.grow(shadow_grow);
-    let shadow        = shadow.translate((shadow_off_x,shadow_off_y));
+/// Return a shadow for the given shape and shadow parameters.
+pub fn from_shape_with_parameters(base_shape:AnyShape,parameters:Parameters) -> AnyShape {
+    let alpha = Var::<f32>::from(1.0);
+    from_shape_with_parameters_and_alpha(base_shape,parameters,&alpha)
+}
 
-    let base_color    = style.get_color(theme::shadow);
-    let base_color    = Var::<color::Rgba>::from(base_color);
+/// Return a shadow for the given shape, shadow parameters and alpha. As in `from_shape_with_alpha`,
+/// the shadow colors will be multiplied with the given alpha value.
+pub fn from_shape_with_parameters_and_alpha
+(base_shape:AnyShape,parameters:Parameters,alpha:&Var<f32>)
+-> AnyShape {
+    let grow          = Var::<f32>::from(parameters.size);
+    let shadow        = base_shape.grow(grow);
+    let shadow        = shadow.translate((parameters.offset_x.px(),parameters.offset_y.px()));
+
+    let base_color    = Var::<color::Rgba>::from(parameters.base_color);
     let base_color    = base_color.multiply_alpha(&alpha);
 
-    let fading_color  = style.get_color(theme::shadow::fading);
-    let fading_color  = Var::<color::Rgba>::from(fading_color);
+    let fading_color  = Var::<color::Rgba>::from(parameters.fading);
     let fading_color  = fading_color.multiply_alpha(&alpha);
-
-    let exp           = style.get_number(theme::shadow::exponent);
 
     let shadow_color  = color::gradient::Linear::<Var<color::LinearRgba>>
     ::new(fading_color.into_linear(),base_color.into_linear());
-    let shadow_color  = shadow_color.sdf_sampler().size(shadow_size)
-        .spread(shadow_spread).exponent(exp);
+    let shadow_color  = shadow_color.sdf_sampler().size(parameters.size).spread(parameters.spread)
+        .exponent(parameters.exponent);
     let shadow        = shadow.fill(shadow_color);
     shadow.into()
 }

--- a/src/rust/ensogl/lib/components/src/shadow.rs
+++ b/src/rust/ensogl/lib/components/src/shadow.rs
@@ -2,7 +2,8 @@
 use crate::prelude::*;
 
 use ensogl_core::data::color;
-use ensogl_core::display::{DomSymbol, style};
+use ensogl_core::display::DomSymbol;
+use ensogl_core::display::style;
 use ensogl_core::display::shape::*;
 use ensogl_core::display::shape::AnyShape;
 use ensogl_core::system::web::StyleSetter;

--- a/src/rust/ensogl/lib/core/src/display/scene.rs
+++ b/src/rust/ensogl/lib/core/src/display/scene.rs
@@ -609,18 +609,19 @@ impl Renderer {
 /// should be abstracted away in the future.
 #[derive(Clone,CloneRef,Debug)]
 pub struct HardcodedLayers {
-    pub viz              : Layer,
-    pub below_main       : Layer,
+    pub viz                    : Layer,
+    pub below_main             : Layer,
     // main <- here is the 'main` layer inserted.
-    pub cursor           : Layer,
-    pub label            : Layer,
+    pub cursor                 : Layer,
+    pub label                  : Layer,
 
-    pub tooltip_background : Layer,
-    pub tooltip_text       : Layer,
+    pub tooltip_background     : Layer,
+    pub tooltip_text           : Layer,
 
-    pub viz_fullscreen : Layer,
-    pub breadcrumbs    : Layer,
-    layers             : Layers,
+    pub viz_fullscreen         : Layer,
+    pub breadcrumbs_background : Layer,
+    pub breadcrumbs_text       : Layer,
+    layers                     : Layers,
 }
 
 impl Deref for HardcodedLayers {
@@ -632,15 +633,16 @@ impl Deref for HardcodedLayers {
 
 impl HardcodedLayers {
     pub fn new(logger:impl AnyLogger) -> Self {
-        let layers             = Layers::new(logger);
-        let viz                = layers.new_layer();
-        let cursor             = layers.new_layer();
-        let label              = layers.new_layer();
-        let tooltip_background = layers.new_layer();
-        let tooltip_text       = layers.new_layer();
-        let viz_fullscreen     = layers.new_layer();
-        let below_main         = layers.new_layer();
-        let breadcrumbs        = layers.new_layer();
+        let layers                 = Layers::new(logger);
+        let viz                    = layers.new_layer();
+        let cursor                 = layers.new_layer();
+        let label                  = layers.new_layer();
+        let tooltip_background     = layers.new_layer();
+        let tooltip_text           = layers.new_layer();
+        let viz_fullscreen         = layers.new_layer();
+        let below_main             = layers.new_layer();
+        let breadcrumbs_background = layers.new_layer();
+        let breadcrumbs_text       = layers.new_layer();
         viz.set_camera(layers.main.camera());
         label.set_camera(layers.main.camera());
         tooltip_background.set_camera(layers.main.camera());
@@ -648,14 +650,15 @@ impl HardcodedLayers {
         below_main.set_camera(layers.main.camera());
         layers.add_layers_order_dependency(&viz,&below_main);
         layers.add_layers_order_dependency(&below_main,&layers.main);
-        layers.add_layers_order_dependency(&layers.main,&cursor);
-        layers.add_layers_order_dependency(&cursor,&label);
-        layers.add_layers_order_dependency(&label,&tooltip_background);
+        layers.add_layers_order_dependency(&layers.main,&label);
+        layers.add_layers_order_dependency(&label,&breadcrumbs_background);
+        layers.add_layers_order_dependency(&breadcrumbs_background,&breadcrumbs_text);
+        layers.add_layers_order_dependency(&breadcrumbs_text,&cursor);
+        layers.add_layers_order_dependency(&cursor,&tooltip_background);
         layers.add_layers_order_dependency(&tooltip_background,&tooltip_text);
         layers.add_layers_order_dependency(&tooltip_text,&viz_fullscreen);
-        layers.add_layers_order_dependency(&viz_fullscreen,&breadcrumbs);
-        Self {layers,viz,cursor,label,viz_fullscreen,below_main,breadcrumbs,tooltip_background,
-              tooltip_text}
+        Self {layers,viz,cursor,label,viz_fullscreen,below_main,breadcrumbs_background,
+            breadcrumbs_text,tooltip_background,tooltip_text}
     }
 }
 

--- a/src/rust/ensogl/lib/theme/src/lib.rs
+++ b/src/rust/ensogl/lib/theme/src/lib.rs
@@ -176,9 +176,18 @@ define_themes! { [light:0, dark:1]
         }
         status_bar {
             text = text, text;
+            background = graph_editor::node::background , graph_editor::node::background;
             background {
-                color = graph_editor::node::background, graph_editor::node::background;
-                corner_radius = 14.0, 14.0;
+                corner_radius = 14.0 , 14.0;
+                shadow = shadow , shadow;
+                shadow {
+                    size     = shadow::size     , shadow::size;
+                    spread   = shadow::spread   , shadow::spread;
+                    fading   = shadow::fading   , shadow::fading;
+                    exponent = shadow::exponent , shadow::exponent;
+                    offset_x = shadow::offset_x , shadow::offset_x;
+                    offset_y = shadow::offset_y , shadow::offset_y;
+                }
             }
         }
     }
@@ -241,7 +250,7 @@ define_themes! { [light:0, dark:1]
                 edited    = Lcha::yellow(0.9,1.0), Lcha::yellow(0.9,1.0);
             }
             error {
-                dataflow      = Rgba(1.0,0.655,0.141,1.0), Rgba(1.0,0.655,0.141,1.0);
+                dataflow     = Rgba(1.0,0.655,0.141,1.0), Rgba(1.0,0.655,0.141,1.0);
                 panic        = Rgba(1.0,0.341,0.125,1.0), Rgba(1.0,0.341,0.125,1.0);
                 width        = 4.0  , 4.0;
                 repeat_x     = 20.0 , 20.0;
@@ -278,9 +287,18 @@ define_themes! { [light:0, dark:1]
                 left  = Lcha(0.0,0.0,0.0,0.5) , Lcha(1.0,0.0,0.0,0.5);
                 right = Lcha(0.0,0.0,0.0,0.2) , Lcha(1.0,0.0,0.0,0.2);
             }
+            background = graph_editor::node::background , graph_editor::node::background;
             background {
-                color = graph_editor::node::background, graph_editor::node::background;
-                corner_radius = 14.0, 14.0;
+                corner_radius = 8.0 , 8.0;
+                shadow = shadow , shadow;
+                shadow {
+                    size     = shadow::size     , shadow::size;
+                    spread   = shadow::spread   , shadow::spread;
+                    fading   = shadow::fading   , shadow::fading;
+                    exponent = shadow::exponent , shadow::exponent;
+                    offset_x = shadow::offset_x , shadow::offset_x;
+                    offset_y = shadow::offset_y , shadow::offset_y;
+                }
             }
         }
         edge {

--- a/src/rust/ensogl/lib/theme/src/lib.rs
+++ b/src/rust/ensogl/lib/theme/src/lib.rs
@@ -176,6 +176,10 @@ define_themes! { [light:0, dark:1]
         }
         status_bar {
             text = text, text;
+            background {
+                color = graph_editor::node::background, graph_editor::node::background;
+                corner_radius = 14.0, 14.0;
+            }
         }
     }
     code {
@@ -273,6 +277,10 @@ define_themes! { [light:0, dark:1]
             deselected  {
                 left  = Lcha(0.0,0.0,0.0,0.5) , Lcha(1.0,0.0,0.0,0.5);
                 right = Lcha(0.0,0.0,0.0,0.2) , Lcha(1.0,0.0,0.0,0.2);
+            }
+            background {
+                color = graph_editor::node::background, graph_editor::node::background;
+                corner_radius = 14.0, 14.0;
             }
         }
         edge {

--- a/src/rust/ide/view/graph-editor/src/component/breadcrumbs.rs
+++ b/src/rust/ide/view/graph-editor/src/component/breadcrumbs.rs
@@ -217,22 +217,24 @@ impl BreadcrumbsModel {
         self.root.set_position(Vector3(x_position.round(), y_position.round(), 0.0));
     }
 
-    fn breadcrumbs_container_size(&self) -> f32 {
+    fn breadcrumbs_container_width(&self) -> f32 {
         self.breadcrumbs.borrow().iter().map(|breadcrumb| breadcrumb.width()).sum()
     }
 
     fn update_layout(&self) {
+        let project_name_width = self.project_name.width.value().round();
+
         self.project_name.set_position_x(HORIZONTAL_PADDING);
-        self.breadcrumbs_container.set_position_x(
-            HORIZONTAL_PADDING + self.project_name.width.value().round());
+        self.breadcrumbs_container.set_position_x(HORIZONTAL_PADDING + project_name_width);
 
         let background_width  = HORIZONTAL_PADDING
-                              + self.project_name.width.value().round()
-                              + self.breadcrumbs_container_size()
+                              + project_name_width
+                              + self.breadcrumbs_container_width()
                               + HORIZONTAL_PADDING;
         let background_height = HEIGHT;
-        self.background.size.set(Vector2(background_width+MAGIC_SHADOW_MARGIN*2.0,
-            background_height+MAGIC_SHADOW_MARGIN*2.0));
+        let width_with_shadow = background_width + MAGIC_SHADOW_MARGIN * 2.0;
+        let height_with_shadow = background_height + MAGIC_SHADOW_MARGIN * 2.0;
+        self.background.size.set(Vector2(width_with_shadow,height_with_shadow));
         self.background.set_position_x(background_width/2.0);
         self.background.set_position_y(-background_height/2.0);
     }
@@ -304,7 +306,7 @@ impl BreadcrumbsModel {
                 }
 
                 debug!(self.logger, "Pushing {breadcrumb.info.method_pointer.name} breadcrumb.");
-                breadcrumb.set_position_x(self.breadcrumbs_container_size().round());
+                breadcrumb.set_position_x(self.breadcrumbs_container_width().round());
                 self.breadcrumbs_container.add_child(&breadcrumb);
                 self.breadcrumbs.borrow_mut().push(breadcrumb);
             }

--- a/src/rust/ide/view/graph-editor/src/component/breadcrumbs.rs
+++ b/src/rust/ide/view/graph-editor/src/component/breadcrumbs.rs
@@ -10,19 +10,20 @@ pub use breadcrumb::Breadcrumb;
 pub use project_name::ProjectName;
 
 use crate::LocalCall;
+use crate::component::breadcrumbs::project_name::LINE_HEIGHT;
 
+use enso_args::ARGS;
 use enso_frp as frp;
 use enso_protocol::language_server::MethodPointer;
 use ensogl::application::Application;
-use ensogl::data::color;
 use ensogl::display::camera::Camera2d;
 use ensogl::display::object::ObjectOps;
 use ensogl::display::shape::*;
 use ensogl::display;
 use ensogl::gui::cursor;
+use ensogl_gui_components::shadow;
 use logger::Logger;
 use std::cmp::Ordering;
-
 
 
 // =================
@@ -30,10 +31,26 @@ use std::cmp::Ordering;
 // =================
 
 // FIXME[dg] hardcoded literal for glyph of height 12.0. Copied from port.rs
-const GLYPH_WIDTH       : f32 = 7.224_609_4;
-const VERTICAL_MARGIN   : f32 = GLYPH_WIDTH;
-const HORIZONTAL_MARGIN : f32 = GLYPH_WIDTH;
-const TEXT_SIZE         : f32 = 12.0;
+const GLYPH_WIDTH                      : f32 = 7.224_609_4;
+const VERTICAL_MARGIN                  : f32 = GLYPH_WIDTH;
+const HORIZONTAL_MARGIN                : f32 = GLYPH_WIDTH;
+const TEXT_SIZE                        : f32 = 12.0;
+const HEIGHT                           : f32 = VERTICAL_MARGIN
+                                             + breadcrumb::VERTICAL_MARGIN
+                                             + breadcrumb::PADDING
+                                             + LINE_HEIGHT
+                                             + breadcrumb::PADDING
+                                             + breadcrumb::VERTICAL_MARGIN
+                                             + VERTICAL_MARGIN;
+
+const MACOS_TRAFFIC_LIGHTS_CONTENT     : f32 = 52.0;
+const MACOS_TRAFFIC_LIGHTS_SIDE_OFFSET : f32 = 13.0;
+const MACOS_TRAFFIC_LIGHTS_WIDTH       : f32 =
+    MACOS_TRAFFIC_LIGHTS_CONTENT + 2.0 * MACOS_TRAFFIC_LIGHTS_SIDE_OFFSET;
+// This should be as large as the shadow around the background.
+const MAGIC_SHADOW_MARGIN              : f32 = 40.0;
+
+const PADDING_RIGHT                    : f32 = MACOS_TRAFFIC_LIGHTS_SIDE_OFFSET;
 
 
 
@@ -57,10 +74,29 @@ mod background {
     use super::*;
 
     ensogl::define_shape_system! {
-        () {
-            let gray     = 34.0/255.0;
-            let bg_color = color::Rgba::new(gray,gray,gray,1.0);
-            Plane().fill(bg_color).into()
+        (style:Style) {
+            let width         = Var::<Pixels>::from("input_size.x");
+            let height        = Var::<Pixels>::from("input_size.y");
+
+            let corner_radius = style.get_number
+                                (ensogl_theme::graph_editor::breadcrumbs::background
+                                ::corner_radius);
+            // The shape will reach outside the screen to the left and the top by the amount of
+            // MAGIC_SHADOW_MARGIN. This is necessary because those parts outside the screen might
+            // still cast shadows on screen.
+            let shape_width   = width - MAGIC_SHADOW_MARGIN.px();
+            let shape_height  = height - MAGIC_SHADOW_MARGIN.px();
+            let shape         = Rect((&shape_width,&shape_height))
+                                .corners_radiuses(0.px(),0.px(),0.px(),corner_radius.px())
+                                .translate_x(-MAGIC_SHADOW_MARGIN.px()/2.0)
+                                .translate_y(MAGIC_SHADOW_MARGIN.px()/2.0);
+
+            let bg_color      = style.get_color
+                                (ensogl_theme::graph_editor::breadcrumbs::background::color);
+            let bg            = shape.fill(bg_color);
+            let shadow        = shadow::from_shape(shape.into(),style);
+
+            (shadow + bg).into()
         }
     }
 }
@@ -138,7 +174,7 @@ pub struct BreadcrumbsModel {
     display_object        : display::object::Instance,
     background            : background::View,
     project_name          : ProjectName,
-    root                   : display::object::Instance,
+    content               : display::object::Instance,
     /// A container for all the breadcrumbs after project name. This contained and all its
     /// breadcrumbs are moved when project name component is resized.
     breadcrumbs_container : display::object::Instance,
@@ -156,7 +192,7 @@ impl BreadcrumbsModel {
         let project_name          = app.new_view();
         let logger                = Logger::new("Breadcrumbs");
         let display_object        = display::object::Instance::new(&logger);
-        let root                  = display::object::Instance::new(&logger);
+        let content               = display::object::Instance::new(&logger);
         let breadcrumbs_container = display::object::Instance::new(&logger);
         let scene                 = scene.clone_ref();
         let breadcrumbs           = default();
@@ -165,14 +201,20 @@ impl BreadcrumbsModel {
         let camera                = scene.camera().clone_ref();
         let background            = background::View::new(&logger);
 
-        Self{logger,display_object,root,app,breadcrumbs,project_name,breadcrumbs_container,
+        scene.layers.breadcrumbs_background.add_exclusive(&background);
+
+        Self{logger,display_object,content,app,breadcrumbs,project_name,breadcrumbs_container,
             frp_inputs,current_index,camera,background}.init()
     }
 
     fn init(self) -> Self {
-        self.add_child(&self.root);
-        self.root.add_child(&self.project_name);
-        self.root.add_child(&self.breadcrumbs_container);
+        self.add_child(&self.content);
+        self.content.add_child(&self.project_name);
+        self.content.add_child(&self.breadcrumbs_container);
+        self.add_child(&self.background);
+
+        self.update_layout();
+
         self
     }
 
@@ -181,15 +223,33 @@ impl BreadcrumbsModel {
         let screen     = camera.screen();
         let x_position = -screen.width/2.0;
         let y_position = screen.height/2.0;
-        self.root.set_position(Vector3(x_position.round(),y_position.round(),0.0));
+        self.set_position(Vector3(x_position.round(), y_position.round(), 0.0));
     }
 
-    fn width(&self) -> f32 {
+    fn breadcrumbs_container_size(&self) -> f32 {
         self.breadcrumbs.borrow().iter().map(|breadcrumb| breadcrumb.width()).sum()
     }
 
-    fn relayout_for_project_name_width(&self, width:f32) {
-        self.breadcrumbs_container.set_position_x(width.round());
+    fn update_layout(&self) {
+        let is_macos     = ARGS.platform.map(|p|p.is_macos()) == Some(true);
+        let is_frameless = ARGS.frame == Some(false);
+        let x_offset     = if is_macos && is_frameless { MACOS_TRAFFIC_LIGHTS_WIDTH }
+                           else                        { MACOS_TRAFFIC_LIGHTS_SIDE_OFFSET };
+        self.content.set_position_x(x_offset);
+
+        self.breadcrumbs_container.set_position_x(self.project_name.width.value().round());
+
+        let background_left   = 0.0;
+        let background_right  = self.content.position().x
+                              + self.breadcrumbs_container.position().x
+                              + self.breadcrumbs_container_size()
+                              + PADDING_RIGHT;
+        let background_width  = background_right - background_left;
+        let background_height = HEIGHT;
+        self.background.size.set(Vector2(background_width+MAGIC_SHADOW_MARGIN*2.0,
+            background_height+MAGIC_SHADOW_MARGIN*2.0));
+        self.background.set_position_x(background_width/2.0);
+        self.background.set_position_y(-background_height/2.0);
     }
 
     fn get_breadcrumb(&self, index:usize) -> Option<Breadcrumb> {
@@ -259,11 +319,12 @@ impl BreadcrumbsModel {
                 }
 
                 debug!(self.logger, "Pushing {breadcrumb.info.method_pointer.name} breadcrumb.");
-                breadcrumb.set_position_x(self.width().round());
+                breadcrumb.set_position_x(self.breadcrumbs_container_size().round());
                 self.breadcrumbs_container.add_child(&breadcrumb);
                 self.breadcrumbs.borrow_mut().push(breadcrumb);
             }
             self.current_index.set(new_index);
+            self.update_layout();
             (old_index,new_index)
         })
     }
@@ -324,6 +385,7 @@ impl BreadcrumbsModel {
             let old_index = self.current_index.get();
             let new_index = old_index - 1;
             self.current_index.set(new_index);
+            self.update_layout();
             (old_index,new_index)
         })
     }
@@ -333,6 +395,7 @@ impl BreadcrumbsModel {
             debug!(self.logger, "Removing {breadcrumb.info.method_pointer.name}.");
             breadcrumb.unset_parent();
         }
+        self.update_layout();
     }
 }
 
@@ -420,12 +483,6 @@ impl Breadcrumbs {
             frp.source.project_name_hovered <+ model.project_name.is_hovered;
             frp.source.project_mouse_down   <+ model.project_name.mouse_down;
 
-            // === GUI Update ===
-
-            eval model.project_name.frp.output.width((width)
-                model.relayout_for_project_name_width(*width)
-            );
-
 
             // === User Interaction ===
 
@@ -458,10 +515,7 @@ impl Breadcrumbs {
             // === Relayout ===
 
             eval_ scene.frp.camera_changed(model.camera_changed());
-
-            eval model.project_name.frp.output.width ((width) {
-                model.relayout_for_project_name_width(*width)
-            });
+            eval_ model.project_name.frp.output.width (model.update_layout());
 
 
             // === Pointer style ===

--- a/src/rust/ide/view/graph-editor/src/component/breadcrumbs.rs
+++ b/src/rust/ide/view/graph-editor/src/component/breadcrumbs.rs
@@ -18,6 +18,7 @@ use ensogl::application::Application;
 use ensogl::display::camera::Camera2d;
 use ensogl::display::object::ObjectOps;
 use ensogl::display::shape::*;
+use ensogl::display::style;
 use ensogl::display;
 use ensogl::gui::cursor;
 use ensogl_gui_components::shadow;
@@ -33,7 +34,6 @@ use std::cmp::Ordering;
 const GLYPH_WIDTH        : f32 = 7.224_609_4;
 const VERTICAL_MARGIN    : f32 = GLYPH_WIDTH;
 const HORIZONTAL_MARGIN  : f32 = GLYPH_WIDTH;
-const OUTER_MARGIN       : f32 = 12.0;
 const HORIZONTAL_PADDING : f32 = 12.0;
 const TEXT_SIZE          : f32 = 12.0;
 const HEIGHT             : f32 = VERTICAL_MARGIN
@@ -70,22 +70,20 @@ mod background {
 
     ensogl::define_shape_system! {
         (style:Style) {
+            let theme             = ensogl_theme::graph_editor::breadcrumbs::background;
+            let theme             = style::Path::from(&theme);
             let width             = Var::<Pixels>::from("input_size.x");
             let height            = Var::<Pixels>::from("input_size.y");
 
-            let corner_radius     = style.get_number
-                                    (ensogl_theme::graph_editor::breadcrumbs::background
-                                    ::corner_radius);
-            let shape_width       = width - MAGIC_SHADOW_MARGIN.px() * 2.0;
+            let corner_radius     = style.get_number(theme.sub("corner_radius"));
+            let shape_width       = width  - MAGIC_SHADOW_MARGIN.px() * 2.0;
             let shape_height      = height - MAGIC_SHADOW_MARGIN.px() * 2.0;
-            let shape             = Rect((&shape_width,&shape_height))
-                                    .corners_radius(corner_radius.px());
+            let shape             = Rect((&shape_width,&shape_height));
+            let shape             = shape.corners_radius(corner_radius.px());
 
-            let bg_color          = style.get_color
-                                    (ensogl_theme::graph_editor::breadcrumbs::background);
+            let bg_color          = style.get_color(&theme);
             let bg                = shape.fill(bg_color);
-            let shadow_parameters = shadow::parameters_from_style_path
-                (style,ensogl_theme::graph_editor::breadcrumbs::background::shadow);
+            let shadow_parameters = shadow::parameters_from_style_path(style,theme.sub("shadow"));
             let shadow            = shadow::from_shape_with_parameters
                 (shape.into(),shadow_parameters);
 
@@ -167,7 +165,7 @@ pub struct BreadcrumbsModel {
     display_object        : display::object::Instance,
     background            : background::View,
     project_name          : ProjectName,
-    root: display::object::Instance,
+    root                  : display::object::Instance,
     /// A container for all the breadcrumbs after project name. This contained and all its
     /// breadcrumbs are moved when project name component is resized.
     breadcrumbs_container : display::object::Instance,
@@ -214,8 +212,8 @@ impl BreadcrumbsModel {
     fn camera_changed(&self) {
         let camera     = &self.camera;
         let screen     = camera.screen();
-        let x_position = -screen.width/2.0 + OUTER_MARGIN;
-        let y_position = screen.height/2.0 - OUTER_MARGIN;
+        let x_position = -screen.width/2.0;
+        let y_position = screen.height/2.0;
         self.root.set_position(Vector3(x_position.round(), y_position.round(), 0.0));
     }
 

--- a/src/rust/ide/view/graph-editor/src/component/breadcrumbs/breadcrumb.rs
+++ b/src/rust/ide/view/graph-editor/src/component/breadcrumbs/breadcrumb.rs
@@ -4,10 +4,10 @@ use crate::prelude::*;
 
 use super::GLYPH_WIDTH;
 use super::HORIZONTAL_MARGIN;
-use super::VERTICAL_MARGIN;
 use super::TEXT_SIZE;
 use super::RelativePosition;
-
+use crate::component::breadcrumbs;
+use crate::component::breadcrumbs::project_name::LINE_HEIGHT;
 use crate::MethodPointer;
 
 use enso_frp as frp;
@@ -29,8 +29,8 @@ use ensogl::application::Application;
 // === Constants ===
 // =================
 
-/// Breadcrumb top margin.
-pub const TOP_MARGIN:f32 = 0.0;
+/// Breadcrumb vertical margin.
+pub const VERTICAL_MARGIN:f32 = 0.0;
 /// Breadcrumb left margin.
 pub const LEFT_MARGIN:f32 = 0.0;
 /// Breadcrumb right margin.
@@ -290,23 +290,23 @@ impl BreadcrumbModel {
         let relative_position = default();
         let outputs           = frp.outputs.clone_ref();
 
-        scene.layers.breadcrumbs.add_exclusive(&view);
-        let shape_system = scene.layers.breadcrumbs.shape_system_registry.shape_system
+        scene.layers.breadcrumbs_background.add_exclusive(&view);
+        let shape_system = scene.layers.breadcrumbs_background.shape_system_registry.shape_system
             (scene,PhantomData::<background::DynamicShape>);
-        scene.layers.breadcrumbs.add_symbol_exclusive(&shape_system.shape_system.symbol);
+        scene.layers.breadcrumbs_background.add_symbol_exclusive(&shape_system.shape_system.symbol);
 
-        scene.layers.breadcrumbs.add_exclusive(&icon);
-        let shape_system = scene.layers.breadcrumbs.shape_system_registry.shape_system
+        scene.layers.breadcrumbs_text.add_exclusive(&icon);
+        let shape_system = scene.layers.breadcrumbs_text.shape_system_registry.shape_system
             (scene,PhantomData::<icon::DynamicShape>);
         shape_system.shape_system.set_pointer_events(false);
 
-        scene.layers.breadcrumbs.add_exclusive(&separator);
-        let shape_system = scene.layers.breadcrumbs.shape_system_registry.shape_system
+        scene.layers.breadcrumbs_background.add_exclusive(&separator);
+        let shape_system = scene.layers.breadcrumbs_background.shape_system_registry.shape_system
             (scene,PhantomData::<separator::DynamicShape>);
         shape_system.shape_system.set_pointer_events(false);
 
         label.remove_from_scene_layer_DEPRECATED(&scene.layers.main);
-        label.add_to_scene_layer_DEPRECATED(&scene.layers.breadcrumbs);
+        label.add_to_scene_layer_DEPRECATED(&scene.layers.breadcrumbs_text);
 
         // FIXME : StyleWatch is unsuitable here, as it was designed as an internal tool for shape
         //         system (#795)
@@ -367,14 +367,14 @@ impl BreadcrumbModel {
 
     /// Get the height of the view.
     pub fn height(&self) -> f32 {
-        TEXT_SIZE + VERTICAL_MARGIN * 2.0
+        LINE_HEIGHT + breadcrumbs::VERTICAL_MARGIN * 2.0
     }
 
     fn fade_in(&self, value:f32) {
         let width      = self.width();
         let height     = self.height();
         let x_position = width*value/2.0;
-        let y_position = -height/2.0-TOP_MARGIN-PADDING;
+        let y_position = -height/2.0-VERTICAL_MARGIN-PADDING;
         self.view.set_position(Vector3(x_position.round(),y_position.round(),0.0));
     }
 

--- a/src/rust/ide/view/graph-editor/src/component/breadcrumbs/project_name.rs
+++ b/src/rust/ide/view/graph-editor/src/component/breadcrumbs/project_name.rs
@@ -146,13 +146,13 @@ impl ProjectNameModel {
         text_field.single_line(true);
 
         text_field.remove_from_scene_layer_DEPRECATED(&scene.layers.main);
-        text_field.add_to_scene_layer_DEPRECATED(&scene.layers.breadcrumbs);
+        text_field.add_to_scene_layer_DEPRECATED(&scene.layers.breadcrumbs_text);
         text_field.hover();
 
         let view_logger = Logger::sub(&logger,"view_logger");
         let view        = background::View::new(&view_logger);
 
-        scene.layers.breadcrumbs.add_exclusive(&view);
+        scene.layers.breadcrumbs_background.add_exclusive(&view);
 
         let project_name = default();
         Self{app,logger,view,style,display_object,text_field,project_name}.init()
@@ -166,19 +166,22 @@ impl ProjectNameModel {
     }
 
     fn update_alignment(&self, content:&str) {
-        let width       = self.width(content);
-        let line_height = LINE_HEIGHT;
-        let height      = line_height+VERTICAL_MARGIN*2.0;
-        let x_position  = breadcrumb::LEFT_MARGIN + breadcrumb::PADDING;
-        let y_position  = -VERTICAL_MARGIN - breadcrumb::TOP_MARGIN - breadcrumb::PADDING;
-        self.text_field.set_position(Vector3(x_position,y_position,0.0));
+        let width    = self.width(content);
+        let x_left   = breadcrumb::LEFT_MARGIN + breadcrumb::PADDING;
+        let x_center = x_left + width/2.0;
+
+        let height   = LINE_HEIGHT;
+        let y_top    = - VERTICAL_MARGIN - breadcrumb::VERTICAL_MARGIN - breadcrumb::PADDING;
+        let y_center = y_top - height/2.0;
+
+        self.text_field.set_position(Vector3(x_left,y_center+TEXT_SIZE/2.0,0.0));
         self.view.size.set(Vector2(width,height));
-        self.view.set_position(Vector3(width,-height,0.0)/2.0);
+        self.view.set_position(Vector3(x_center,y_center,0.0));
     }
 
     fn init(self) -> Self {
         self.add_child(&self.text_field);
-        self.text_field.add_child(&self.view);
+        self.add_child(&self.view);
         self.update_text_field_content(self.project_name.borrow().as_str());
         self
     }

--- a/src/rust/ide/view/graph-editor/src/lib.rs
+++ b/src/rust/ide/view/graph-editor/src/lib.rs
@@ -43,6 +43,7 @@ use crate::component::visualization::MockDataGenerator3D;
 use crate::component::visualization;
 use crate::data::enso;
 
+use enso_args::ARGS;
 use enso_frp as frp;
 use ensogl::DEPRECATED_Animation;
 use ensogl::DEPRECATED_Tween;
@@ -80,6 +81,10 @@ pub mod prelude {
 
 const SNAP_DISTANCE_THRESHOLD          : f32 = 10.0;
 const VIZ_PREVIEW_MODE_TOGGLE_TIME_MS  : f32 = 300.0;
+const MACOS_TRAFFIC_LIGHTS_CONTENT     : f32 = 52.0;
+const MACOS_TRAFFIC_LIGHTS_SIDE_OFFSET : f32 = 13.0;
+const MACOS_TRAFFIC_LIGHTS_WIDTH       : f32 =
+    MACOS_TRAFFIC_LIGHTS_CONTENT + 2.0 * MACOS_TRAFFIC_LIGHTS_SIDE_OFFSET;
 
 
 
@@ -1265,6 +1270,11 @@ impl GraphEditorModel {
 
     fn init(self) -> Self {
         self.add_child(&self.breadcrumbs);
+        let is_macos     = ARGS.platform.map(|p|p.is_macos()) == Some(true);
+        let is_frameless = ARGS.frame == Some(false);
+        let x_offset     = if is_macos && is_frameless { MACOS_TRAFFIC_LIGHTS_WIDTH }
+                           else                        { 0.0 };
+        self.breadcrumbs.set_position_x(x_offset);
         self.scene().add_child(&self.tooltip);
         self
     }

--- a/src/rust/ide/view/graph-editor/src/lib.rs
+++ b/src/rust/ide/view/graph-editor/src/lib.rs
@@ -43,7 +43,6 @@ use crate::component::visualization::MockDataGenerator3D;
 use crate::component::visualization;
 use crate::data::enso;
 
-use enso_args::ARGS;
 use enso_frp as frp;
 use ensogl::DEPRECATED_Animation;
 use ensogl::DEPRECATED_Tween;
@@ -81,10 +80,6 @@ pub mod prelude {
 
 const SNAP_DISTANCE_THRESHOLD          : f32 = 10.0;
 const VIZ_PREVIEW_MODE_TOGGLE_TIME_MS  : f32 = 300.0;
-const MACOS_TRAFFIC_LIGHTS_CONTENT     : f32 = 52.0;
-const MACOS_TRAFFIC_LIGHTS_SIDE_OFFSET : f32 = 13.0;
-const MACOS_TRAFFIC_LIGHTS_WIDTH       : f32 =
-    MACOS_TRAFFIC_LIGHTS_CONTENT + 2.0 * MACOS_TRAFFIC_LIGHTS_SIDE_OFFSET;
 
 
 
@@ -1270,12 +1265,6 @@ impl GraphEditorModel {
 
     fn init(self) -> Self {
         self.add_child(&self.breadcrumbs);
-        let is_macos     = ARGS.platform.map(|p|p.is_macos()) == Some(true);
-        let is_frameless = ARGS.frame == Some(false);
-        let x_offset     = if is_macos && is_frameless { MACOS_TRAFFIC_LIGHTS_WIDTH }
-                           else                        { MACOS_TRAFFIC_LIGHTS_SIDE_OFFSET };
-        self.breadcrumbs.set_position_x(x_offset);
-        self.breadcrumbs.set_position_y(-5.0);
         self.scene().add_child(&self.tooltip);
         self
     }

--- a/src/rust/ide/view/graph-editor/src/lib.rs
+++ b/src/rust/ide/view/graph-editor/src/lib.rs
@@ -1273,8 +1273,10 @@ impl GraphEditorModel {
         let is_macos     = ARGS.platform.map(|p|p.is_macos()) == Some(true);
         let is_frameless = ARGS.frame == Some(false);
         let x_offset     = if is_macos && is_frameless { MACOS_TRAFFIC_LIGHTS_WIDTH }
-                           else                        { 0.0 };
+                           else                        { MACOS_TRAFFIC_LIGHTS_SIDE_OFFSET };
+        let y_offset     = -MACOS_TRAFFIC_LIGHTS_SIDE_OFFSET;
         self.breadcrumbs.set_position_x(x_offset);
+        self.breadcrumbs.set_position_y(y_offset);
         self.scene().add_child(&self.tooltip);
         self
     }

--- a/src/rust/ide/view/src/code_editor.rs
+++ b/src/rust/ide/view/src/code_editor.rs
@@ -72,7 +72,7 @@ impl View {
 
         model.set_position_x(PADDING_LEFT);
         model.remove_from_scene_layer_DEPRECATED(&scene.layers.main);
-        model.add_to_scene_layer_DEPRECATED(&scene.layers.breadcrumbs);
+        model.add_to_scene_layer_DEPRECATED(&scene.layers.breadcrumbs_text);
         // TODO[ao]: To have code editor usable we treat it as constantly mouse-hovered, but this
         //  should be changed in the second part of focus management
         //  (https://github.com/enso-org/ide/issues/823)

--- a/src/rust/ide/view/src/debug_scenes/interface.rs
+++ b/src/rust/ide/view/src/debug_scenes/interface.rs
@@ -10,6 +10,7 @@ use crate::graph_editor;
 use crate::graph_editor::GraphEditor;
 use crate::graph_editor::Type;
 use crate::project;
+use crate::status_bar;
 
 use enso_frp as frp;
 use ensogl::display::navigation::navigator::Navigator;
@@ -99,6 +100,9 @@ fn init(app:&Application) {
     world.add_child(&project_view);
 
     code_editor.text_area().set_content(STUB_MODULE.to_owned());
+
+    project_view.status_bar().add_event(status_bar::event::Label::new("This is a status message."));
+    graph_editor.debug_push_breadcrumb();
 
 
     // === Nodes ===

--- a/src/rust/ide/view/src/status_bar.rs
+++ b/src/rust/ide/view/src/status_bar.rs
@@ -7,10 +7,14 @@
 //    description
 use crate::prelude::*;
 
+use crate::graph_editor::component::node::input::area::TEXT_SIZE;
+
 use ensogl::application::Application;
+use ensogl::display::camera::Camera2d;
 use ensogl::display::Scene;
-use ensogl::display::shape::StyleWatch;
+use ensogl::display::shape::*;
 use ensogl::display;
+use ensogl_gui_components::shadow;
 use ensogl_text as text;
 use ensogl_theme as theme;
 use std::future::Future;
@@ -22,9 +26,11 @@ use std::future::Future;
 // =================
 
 /// The height of the status bar.
-pub const HEIGHT:f32 = 40.0;
+const HEIGHT              : f32 = 28.0;
 /// Padding inside the status bar.
-pub const PADDING:f32 = 12.0;
+pub const PADDING         : f32 = 12.0;
+// This should be as large as the shadow around the background.
+const MAGIC_SHADOW_MARGIN : f32 = 40.0;
 
 
 
@@ -75,6 +81,42 @@ pub mod process {
 
 
 
+// ==================
+// === Background ===
+// ==================
+
+mod background {
+    use super::*;
+
+    ensogl::define_shape_system! {
+        (style:Style) {
+            let width         = Var::<Pixels>::from("input_size.x");
+            let height        = Var::<Pixels>::from("input_size.y");
+
+            let corner_radius = style.get_number
+                                (ensogl_theme::application::status_bar::background::corner_radius);
+            // The shape will reach outside the screen to the left and the top by the amount of
+            // MAGIC_SHADOW_MARGIN. This is necessary because those parts outside the screen might
+            // still cast shadows on screen.
+            let shape_width   = width - MAGIC_SHADOW_MARGIN.px();
+            let shape_height  = height - MAGIC_SHADOW_MARGIN.px();
+            let shape         = Rect((&shape_width,&shape_height))
+                                .corners_radiuses(0.px(),corner_radius.px(),0.px(),0.px())
+                                .translate_x(-MAGIC_SHADOW_MARGIN.px()/2.0)
+                                .translate_y(-MAGIC_SHADOW_MARGIN.px()/2.0);
+
+            let bg_color      = style.get_color
+                                (ensogl_theme::application::status_bar::background::color);
+            let bg            = shape.fill(bg_color);
+            let shadow        = shadow::from_shape(shape.into(),style);
+
+            (shadow + bg).into()
+        }
+    }
+}
+
+
+
 // ===========
 // === FRP ===
 // ===========
@@ -86,7 +128,6 @@ ensogl::define_endpoints! {
         finish_process (process::Id),
     }
     Output {
-        width             (f32),
         last_event        (event::Id),
         last_process      (process::Id),
         displayed_event   (Option<event::Id>),
@@ -105,21 +146,29 @@ ensogl::define_endpoints! {
 struct Model {
     logger          : Logger,
     display_object  : display::object::Instance,
+    background      : background::View,
     label           : text::Area,
     events          : Rc<RefCell<Vec<event::Label>>>,
     processes       : Rc<RefCell<HashMap<process::Id,process::Label>>>,
     next_process_id : Rc<RefCell<process::Id>>,
+    camera          : Camera2d,
 }
 
 impl Model {
     fn new(app:&Application) -> Self {
+        let scene           = app.display.scene();
         let logger          = Logger::new("StatusBar");
         let display_object  = display::object::Instance::new(&logger);
+        let background      = background::View::new(&logger);
         let label           = text::Area::new(app);
         let events          = default();
         let processes       = default();
         let next_process_id = default();
-        display_object.add_child(&label);
+        let camera          = scene.camera();
+
+        scene.layers.breadcrumbs_background.add_exclusive(&background);
+        label.remove_from_scene_layer_DEPRECATED(&scene.layers.main);
+        label.add_to_scene_layer_DEPRECATED(&scene.layers.breadcrumbs_text);
 
         let text_color_path = theme::application::status_bar::text;
         let style           = StyleWatch::new(&app.display.scene().style_sheet);
@@ -127,11 +176,39 @@ impl Model {
         label.frp.set_color_all.emit(text_color);
         label.frp.set_default_color.emit(text_color);
 
-        Self {logger,display_object,label,events,processes,next_process_id}
+        Self {logger,display_object,background,label,events,processes,next_process_id,camera}.init()
     }
 
-    fn set_width(&self, width:f32) {
-        self.label.set_position_x(-width/2.0 + PADDING);
+    fn init(self) -> Self {
+        self.display_object.add_child(&self.background);
+        self.display_object.add_child(&self.label);
+
+        self.update_layout();
+
+        self
+    }
+
+    fn camera_changed(&self) {
+        let screen = self.camera.screen();
+        let x = -screen.width/2.0;
+        let y = -screen.height/2.0;
+        self.display_object.set_position_x(x.round());
+        self.display_object.set_position_y(y.round());
+    }
+
+    fn update_layout(&self) {
+        self.label.set_position_x(PADDING);
+        self.label.set_position_y(HEIGHT/2.0 + TEXT_SIZE/2.0);
+
+        let bg_width = if self.label.width.value() > 0.0 {
+            PADDING + self.label.width.value() + PADDING
+        } else {
+            0.0
+        };
+        let bg_height = HEIGHT;
+        self.background.size.set(Vector2(bg_width+2.0*MAGIC_SHADOW_MARGIN,
+            bg_height+2.0*MAGIC_SHADOW_MARGIN));
+        self.background.set_position(Vector3(bg_width/2.0,bg_height/2.0,0.0));
     }
 
     fn add_event(&self, label:&event::Label) -> event::Id {
@@ -184,10 +261,6 @@ impl View {
         let model       = Model::new(&app);
         let network     = &frp.network;
         let scene       = app.display.scene();
-        let scene_shape = scene.shape().clone_ref();
-
-        model.label.remove_from_scene_layer_DEPRECATED(&scene.layers.main);
-        model.label.add_to_scene_layer_DEPRECATED(&scene.layers.breadcrumbs);
 
         enso_frp::extend! { network
             event_added       <- frp.add_event.map(f!((label) model.add_event(label)));
@@ -219,15 +292,9 @@ impl View {
             frp.source.displayed_process <+ event_added.constant(None);
             frp.source.displayed_process <+ displayed_process_finished.constant(None);
 
-            width <- scene_shape.map(|scene_shape| scene_shape.width);
-            eval width ((width) model.set_width(*width));
-            eval scene_shape ((scene_shape)
-                model.display_object.set_position_y(-scene_shape.height / 2.0 + HEIGHT / 2.0);
-            );
-            frp.source.width <+ width;
+            eval_ model.label.output.width (model.update_layout());
+            eval_ scene.frp.camera_changed (model.camera_changed());
         }
-
-        model.set_width(scene_shape.value().width);
 
         Self {frp,model}
     }

--- a/src/rust/ide/view/src/status_bar.rs
+++ b/src/rust/ide/view/src/status_bar.rs
@@ -13,6 +13,7 @@ use ensogl::application::Application;
 use ensogl::display::camera::Camera2d;
 use ensogl::display::Scene;
 use ensogl::display::shape::*;
+use ensogl::display::style;
 use ensogl::display;
 use ensogl_gui_components::shadow;
 use ensogl_text as text;
@@ -92,21 +93,20 @@ mod background {
 
     ensogl::define_shape_system! {
         (style:Style) {
+            let theme             = ensogl_theme::application::status_bar::background;
+            let theme             = style::Path::from(theme);
             let width             = Var::<Pixels>::from("input_size.x");
             let height            = Var::<Pixels>::from("input_size.y");
 
-            let corner_radius     = style.get_number
-                                    (ensogl_theme::application::status_bar::background::corner_radius);
+            let corner_radius     = style.get_number(theme.sub("corner_radius"));
             let shape_width       = width  - MAGIC_SHADOW_MARGIN.px() * 2.0;
             let shape_height      = height - MAGIC_SHADOW_MARGIN.px() * 2.0;
-            let shape             = Rect((&shape_width,&shape_height))
-                                    .corners_radius(corner_radius.px());
+            let shape             = Rect((&shape_width,&shape_height));
+            let shape             = shape.corners_radius(corner_radius.px());
 
-            let bg_color          = style.get_color
-                                    (ensogl_theme::application::status_bar::background);
+            let bg_color          = style.get_color(&theme);
             let bg                = shape.fill(bg_color);
-            let shadow_parameters = shadow::parameters_from_style_path
-                (style,ensogl_theme::application::status_bar::background::shadow);
+            let shadow_parameters = shadow::parameters_from_style_path(style,theme.sub("shadow"));
             let shadow            = shadow::from_shape_with_parameters
                 (shape.into(),shadow_parameters);
 


### PR DESCRIPTION
### Pull Request Description
<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->
This adds a background to the breadcrumbs and statusbar, solving issue #1398. Background color and corner radius for each can be set through the theme.

<kbd><img src="https://user-images.githubusercontent.com/8134934/114054477-cf3fbd80-9887-11eb-857c-9e5f146b49ab.png" /></kbd>


### Important Notes
<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->
The implementation is strongly coupled with the internals of breadcrumbs and the status bar. This is necessary to compute the width and height of those components and to track their changes. We could improve this in the future through introduction of a generic layout mechanism.

### Checklist
Please include the following checklist in your PR:

- [x] The `CHANGELOG.md` was updated with the changes introduced in this PR.
- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guide.
- [ ] All code has automatic tests where possible.
- [ ] All code has been profiled where possible.
- [x] All code has been manually tested in the IDE.
- [x] All code has been manually tested in the "debug/interface" scene.
- [ ] All code has been manually tested by the PR owner against our [test scenarios](https://docs.google.com/spreadsheets/d/1RatJDM_f9_3bvYhl3Bpq2d8SyKgtVdrV1RkGxPU17c8/edit?ts=5faa7049#gid=0).
- [ ] All code has been manually tested by at least one reviewer against our [test scenarios](https://docs.google.com/spreadsheets/d/1RatJDM_f9_3bvYhl3Bpq2d8SyKgtVdrV1RkGxPU17c8/edit?ts=5faa7049#gid=0).
