### PR TITLE
Fixes heatmap and visualizations colors in dark mode.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,8 @@
   `--theme=dark` option to enable it.
 - You can hide the node labels with `--no-node-labels` option. This is useful
   when creating demo videos.
-- [Added Heatmap visualization.][1438]
+- [Added Heatmap visualization.][1438] Just as Scatter Plot, it supports
+  visualizing Table, and vectors.
 - [Image visualization.][1367]. Visualizations for the Enso Image library. Now
   You can display Image type and string with image encoded in base64. Histogram
   visualization has been adjusted, allowing to display the values of the

--- a/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/heatmap.js
+++ b/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/heatmap.js
@@ -66,6 +66,8 @@ class Heatmap extends Visualization {
             return rawData.data
         } else if (Array.isArray(rawData)) {
             return rawData
+        } else if (ok(rawData.json) && Array.isArray(rawData.json)) {
+            return rawData.json
         }
         return []
     }
@@ -151,6 +153,17 @@ class Heatmap extends Visualization {
      */
     initHeatmap() {
         let data = this.data()
+        if (ok(data.length) && data.length === 2 && Array.isArray(data[1])) {
+            let indices = Array.from(Array(data[1].length).keys())
+            data = [data[0], indices, data[1]]
+        } else if (!Array.isArray(data[0])) {
+            let indices = Array.from(Array(data.length).keys())
+            data = [indices, [1], data]
+        } else if (ok(data.length) && data.length === 1 && Array.isArray(data[0])) {
+            let indices = Array.from(Array(data[0].length).keys())
+            data = [indices, [1], data[0]]
+        }
+
         // Labels of row and columns
         let myGroups = d3.map(data[0], d => d).keys()
         let myVars = d3.map(data[1], d => d).keys()

--- a/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/heatmap.js
+++ b/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/heatmap.js
@@ -105,6 +105,17 @@ class Heatmap extends Visualization {
         divElem.setAttributeNS(null, 'width', '100%')
         divElem.setAttributeNS(null, 'height', '100%')
 
+        const addStyleToElem = (attr, stl) => {
+            const style = document.createElement('style')
+            style.innerText = attr + '{' + stl + '}'
+
+            divElem.appendChild(style)
+        }
+
+        const darkStrokeColor = `rgba(255,255,255,0.7)`
+
+        addStyleToElem('.dark-theme text', `fill: ${darkStrokeColor};`)
+
         return divElem
     }
 
@@ -193,8 +204,14 @@ class Heatmap extends Visualization {
      * Sets size of the main parent DOM object.
      */
     setSize(size) {
+        while (this.dom.firstChild) {
+            this.dom.removeChild(this.dom.lastChild)
+        }
+
         this.dom.setAttributeNS(null, 'width', size[0])
         this.dom.setAttributeNS(null, 'height', size[1])
+        this.initCanvas()
+        this.initHeatmap()
     }
 }
 

--- a/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/heatmap.js
+++ b/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/heatmap.js
@@ -168,25 +168,42 @@ class Heatmap extends Visualization {
         let myGroups = d3.map(data[0], d => d).keys()
         let myVars = d3.map(data[1], d => d).keys()
         let labelStyle = 'font-family: DejaVuSansMonoBook; font-size: 10px;'
+        let self = this
 
         // Build X scales and axis:
         let x = d3.scaleBand().range([0, this.canvas.inner.width]).domain(myGroups).padding(0.05)
+        let xAxis = d3
+            .axisBottom(x)
+            .tickSize(0)
+            .tickValues(
+                myGroups.filter((d, i) => {
+                    if (i == myGroups.length-1){ return 1 }
+                    let divisor = (5 * self.canvas.outer.width) / 200
+                    return !(i % Math.round(myGroups.length / divisor))
+                })
+            )
+
         this.svg
             .append('g')
             .attr('style', labelStyle)
             .attr('transform', 'translate(0,' + this.canvas.inner.height + ')')
-            .call(d3.axisBottom(x).tickSize(0))
+            .call(xAxis)
             .select('.domain')
             .remove()
 
         // Build Y scales and axis:
         let y = d3.scaleBand().range([this.canvas.inner.height, 0]).domain(myVars).padding(0.05)
-        this.svg
-            .append('g')
-            .attr('style', labelStyle)
-            .call(d3.axisLeft(y).tickSize(0))
-            .select('.domain')
-            .remove()
+        let yAxis = d3
+            .axisLeft(y)
+            .tickSize(0)
+            .tickValues(
+                myVars.filter((d, i) => {
+                    if (i == myVars.length-1){ return 1 }
+                    let divisor = (9 * self.canvas.outer.height) / 200
+                    return !(i % Math.round(myVars.length / divisor))
+                })
+            )
+        this.svg.append('g').attr('style', labelStyle).call(yAxis).select('.domain').remove()
 
         // Build color scale
         let fill = d3

--- a/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/heatmap.js
+++ b/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/heatmap.js
@@ -177,7 +177,9 @@ class Heatmap extends Visualization {
             .tickSize(0)
             .tickValues(
                 myGroups.filter((d, i) => {
-                    if (i == myGroups.length-1){ return 1 }
+                    if (i == myGroups.length - 1) {
+                        return 1
+                    }
                     let divisor = (5 * self.canvas.outer.width) / 200
                     return !(i % Math.round(myGroups.length / divisor))
                 })
@@ -198,7 +200,9 @@ class Heatmap extends Visualization {
             .tickSize(0)
             .tickValues(
                 myVars.filter((d, i) => {
-                    if (i == myVars.length-1){ return 1 }
+                    if (i == myVars.length - 1) {
+                        return 1
+                    }
                     let divisor = (9 * self.canvas.outer.height) / 200
                     return !(i % Math.round(myVars.length / divisor))
                 })

--- a/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/heatmap.js
+++ b/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/heatmap.js
@@ -158,10 +158,10 @@ class Heatmap extends Visualization {
             data = [data[0], indices, data[1]]
         } else if (!Array.isArray(data[0])) {
             let indices = Array.from(Array(data.length).keys())
-            data = [indices, [1], data]
+            data = [indices, [], data]
         } else if (ok(data.length) && data.length === 1 && Array.isArray(data[0])) {
             let indices = Array.from(Array(data[0].length).keys())
-            data = [indices, [1], data[0]]
+            data = [indices, [], data[0]]
         }
 
         // Labels of row and columns

--- a/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/histogram.js
+++ b/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/histogram.js
@@ -458,8 +458,14 @@ class Histogram extends Visualization {
      */
     rescale(scale, withAnimation) {
         const duration = withAnimation ? ANIMATION_DURATION : 0.0
-        this.xAxis.transition().duration(duration).call(d3.axisBottom(scale.x).ticks(5*this.canvasDimensions().outer.width/200))
-        this.yAxis.transition().duration(duration).call(d3.axisLeft(scale.y).ticks(10*this.canvasDimensions().outer.width/200))
+        this.xAxis
+            .transition()
+            .duration(duration)
+            .call(d3.axisBottom(scale.x).ticks((5 * this.canvasDimensions().outer.width) / 200))
+        this.yAxis
+            .transition()
+            .duration(duration)
+            .call(d3.axisLeft(scale.y).ticks((10 * this.canvasDimensions().outer.height) / 200))
         this.plot
             .selectAll('rect')
             .transition()
@@ -511,7 +517,7 @@ class Histogram extends Visualization {
 
         this.xAxis
             .attr('transform', 'translate(0,' + this.canvas.inner.height + ')')
-            .call(d3.axisBottom(x).ticks(5*this.canvasDimensions().outer.width/200))
+            .call(d3.axisBottom(x).ticks((5 * this.canvasDimensions().outer.width) / 200))
 
         let bins
         if (ok(this._dataBins)) {
@@ -533,7 +539,7 @@ class Histogram extends Visualization {
 
         const yAxis = d3.axisLeft(y).tickValues(yAxisTicks).tickFormat(d3.format('d'))
 
-        this.yAxis.call(yAxis.ticks(10*this.canvasDimensions().outer.width/200))
+        this.yAxis.call(yAxis.ticks((10 * this.canvasDimensions().outer.height) / 200))
 
         const fill = d3
             .scaleSequential()

--- a/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/histogram.js
+++ b/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/histogram.js
@@ -458,8 +458,8 @@ class Histogram extends Visualization {
      */
     rescale(scale, withAnimation) {
         const duration = withAnimation ? ANIMATION_DURATION : 0.0
-        this.xAxis.transition().duration(duration).call(d3.axisBottom(scale.x))
-        this.yAxis.transition().duration(duration).call(d3.axisLeft(scale.y))
+        this.xAxis.transition().duration(duration).call(d3.axisBottom(scale.x).ticks(5*this.canvasDimensions().outer.width/200))
+        this.yAxis.transition().duration(duration).call(d3.axisLeft(scale.y).ticks(10*this.canvasDimensions().outer.width/200))
         this.plot
             .selectAll('rect')
             .transition()
@@ -511,7 +511,7 @@ class Histogram extends Visualization {
 
         this.xAxis
             .attr('transform', 'translate(0,' + this.canvas.inner.height + ')')
-            .call(d3.axisBottom(x))
+            .call(d3.axisBottom(x).ticks(5*this.canvasDimensions().outer.width/200))
 
         let bins
         if (ok(this._dataBins)) {
@@ -533,7 +533,7 @@ class Histogram extends Visualization {
 
         const yAxis = d3.axisLeft(y).tickValues(yAxisTicks).tickFormat(d3.format('d'))
 
-        this.yAxis.call(yAxis)
+        this.yAxis.call(yAxis.ticks(10*this.canvasDimensions().outer.width/200))
 
         const fill = d3
             .scaleSequential()
@@ -706,22 +706,22 @@ class Histogram extends Visualization {
         )
 
         addStyleToElem(
-            '.dark button',
+            '.dark-theme button',
             `
             border: 0;
             background-color: ${darkStrokeColor};
         `
         )
         addStyleToElem(
-            '.dark button:hover',
+            '.dark-theme button:hover',
             `
             background-color: ${darkBtnHoverColor};
         `
         )
-        addStyleToElem('.dark .selection', `fill: ${darkSelectionFill}`)
-        addStyleToElem('.dark line', `stroke: ${darkStrokeColor};`)
-        addStyleToElem('.dark .domain', `stroke: ${darkStrokeColor};`)
-        addStyleToElem('.dark text', `fill: ${darkStrokeColor};`)
+        addStyleToElem('.dark-theme .selection', `fill: ${darkSelectionFill}`)
+        addStyleToElem('.dark-theme line', `stroke: ${darkStrokeColor};`)
+        addStyleToElem('.dark-theme .domain', `stroke: ${darkStrokeColor};`)
+        addStyleToElem('.dark-theme text', `fill: ${darkStrokeColor};`)
 
         return divElem
     }

--- a/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/scatterPlot.js
+++ b/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/scatterPlot.js
@@ -274,9 +274,15 @@ class ScatterPlot extends Visualization {
             }
 
             scaleAndAxis.xAxis.call(
-                d3.axisBottom(transformedScale.xScale).ticks(boxWidth / X_AXIS_LABEL_WIDTH)
+                d3
+                    .axisBottom(transformedScale.xScale)
+                    .ticks((5 * self.dom.getAttributeNS(null, 'width')) / 200)
             )
-            scaleAndAxis.yAxis.call(d3.axisLeft(transformedScale.yScale))
+            scaleAndAxis.yAxis.call(
+                d3
+                    .axisLeft(transformedScale.yScale)
+                    .ticks((10 * self.dom.getAttributeNS(null, 'height')) / 200)
+            )
             scatter
                 .selectAll('path')
                 .attr(
@@ -410,11 +416,19 @@ class ScatterPlot extends Visualization {
         scaleAndAxis.xAxis
             .transition()
             .duration(ANIMATION_DURATION)
-            .call(d3.axisBottom(scaleAndAxis.xScale).ticks(boxWidth / X_AXIS_LABEL_WIDTH))
+            .call(
+                d3
+                    .axisBottom(scaleAndAxis.xScale)
+                    .ticks((5 * this.dom.getAttributeNS(null, 'width')) / 200)
+            )
         scaleAndAxis.yAxis
             .transition()
             .duration(ANIMATION_DURATION)
-            .call(d3.axisLeft(scaleAndAxis.yScale))
+            .call(
+                d3
+                    .axisLeft(scaleAndAxis.yScale)
+                    .ticks((10 * this.dom.getAttributeNS(null, 'height')) / 200)
+            )
 
         scatter
             .selectAll('path')
@@ -586,11 +600,14 @@ class ScatterPlot extends Visualization {
             .append('g')
             .attr('transform', 'translate(0,' + boxHeight + ')')
             .attr('style', LABEL_STYLE)
-            .call(d3.axisBottom(xScale).ticks(boxWidth / X_AXIS_LABEL_WIDTH))
+            .call(d3.axisBottom(xScale).ticks((5 * this.dom.getAttributeNS(null, 'width')) / 200))
 
         let yScale = this.axisD3Scale(axis?.y)
         yScale.domain(domainY).range([boxHeight, 0])
-        let yAxis = svg.append('g').attr('style', LABEL_STYLE).call(d3.axisLeft(yScale))
+        let yAxis = svg
+            .append('g')
+            .attr('style', LABEL_STYLE)
+            .call(d3.axisLeft(yScale).ticks((10 * this.dom.getAttributeNS(null, 'height')) / 200))
         return { xScale: xScale, yScale: yScale, xAxis: xAxis, yAxis: yAxis }
     }
 


### PR DESCRIPTION
### Pull Request Description
Fixed some things. Here are results:
Fixed dark to light font in dark mode:
<img width="283" alt="Zrzut ekranu 2021-04-8 o 20 11 57" src="https://user-images.githubusercontent.com/26655166/114082589-3c664980-98ae-11eb-9137-3911dfadb0d7.png">

Heatmap previously worked only on 3-column tables. Now it shows data on a 1D vector, vector of vectors, single- or double-column table:
<img width="213" alt="Zrzut ekranu 2021-04-8 o 21 00 47" src="https://user-images.githubusercontent.com/26655166/114082617-438d5780-98ae-11eb-8498-162a5667458e.png">
Especially this noise -> sort demo that i like:
<img width="513" alt="Zrzut ekranu 2021-04-8 o 21 10 30" src="https://user-images.githubusercontent.com/26655166/114083132-eb0a8a00-98ae-11eb-8755-0c5f616d87fa.png">

And a full screen heatmap:
<img width="838" alt="Zrzut ekranu 2021-04-8 o 20 13 35" src="https://user-images.githubusercontent.com/26655166/114082656-49833880-98ae-11eb-9f19-975069ad4423.png">


### Important Notes
<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist
Please include the following checklist in your PR:

- [ ] The `CHANGELOG.md` was updated with the changes introduced in this PR.
- [ ] The documentation has been updated if necessary.
- [ ] All code conforms to the [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guide.
- [ ] All code has automatic tests where possible.
- [ ] All code has been profiled where possible.
- [ ] All code has been manually tested in the IDE.
- [ ] All code has been manually tested in the "debug/interface" scene.
- [ ] All code has been manually tested by the PR owner against our [test scenarios](https://docs.google.com/spreadsheets/d/1RatJDM_f9_3bvYhl3Bpq2d8SyKgtVdrV1RkGxPU17c8/edit?ts=5faa7049#gid=0).
- [ ] All code has been manually tested by at least one reviewer against our [test scenarios](https://docs.google.com/spreadsheets/d/1RatJDM_f9_3bvYhl3Bpq2d8SyKgtVdrV1RkGxPU17c8/edit?ts=5faa7049#gid=0).
