### PR TITLE
Fix non-selectable crumbs

### DIFF
--- a/src/rust/ide/view/graph-editor/src/component/breadcrumbs.rs
+++ b/src/rust/ide/view/graph-editor/src/component/breadcrumbs.rs
@@ -17,6 +17,7 @@ use enso_protocol::language_server::MethodPointer;
 use ensogl::application::Application;
 use ensogl::display::camera::Camera2d;
 use ensogl::display::object::ObjectOps;
+use ensogl::display::Scene;
 use ensogl::display::shape::*;
 use ensogl::display::style;
 use ensogl::display;
@@ -195,14 +196,20 @@ impl BreadcrumbsModel {
         scene.layers.breadcrumbs_background.add_exclusive(&background);
 
         Self{logger,display_object, root,app,breadcrumbs,project_name,breadcrumbs_container,
-            frp_inputs,current_index,camera,background}.init()
+            frp_inputs,current_index,camera,background}.init(&scene)
     }
 
-    fn init(self) -> Self {
+    fn init(self, scene:&Scene) -> Self {
         self.add_child(&self.root);
         self.root.add_child(&self.project_name);
         self.root.add_child(&self.breadcrumbs_container);
         self.root.add_child(&self.background);
+
+        ensogl::shapes_order_dependencies! {
+            scene => {
+                background -> breadcrumb::background;
+            }
+        }
 
         self.update_layout();
 

--- a/src/rust/ide/view/graph-editor/src/component/breadcrumbs/breadcrumb.rs
+++ b/src/rust/ide/view/graph-editor/src/component/breadcrumbs/breadcrumb.rs
@@ -52,7 +52,8 @@ const SEPARATOR_MARGIN : f32 = 10.0;
 // === Background ===
 // ==================
 
-mod background {
+/// A transparent "background" of single breadcrumb, set for capturing mouse events.
+pub mod background {
     use super::*;
 
     ensogl::define_shape_system! {


### PR DESCRIPTION
### Pull Request Description
The invisible "background" of crumbs appeared below the all panel background.

### Important Notes
Still there is an issue with cursor being under the breadcrumb panel, however I don't know how to fix it. @wdanilo 

### Checklist
Please include the following checklist in your PR:

- [ ] ~~The `CHANGELOG.md` was updated with the changes introduced in this PR.~~
- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guide.
- [x] All code has automatic tests where possible.
- [x] All code has been profiled where possible.
- [x] All code has been manually tested in the IDE.
- [x] All code has been manually tested in the "debug/interface" scene.
- [ ] All code has been manually tested by the PR owner against our [test scenarios](https://docs.google.com/spreadsheets/d/1RatJDM_f9_3bvYhl3Bpq2d8SyKgtVdrV1RkGxPU17c8/edit?ts=5faa7049#gid=0).
- [ ] All code has been manually tested by at least one reviewer against our [test scenarios](https://docs.google.com/spreadsheets/d/1RatJDM_f9_3bvYhl3Bpq2d8SyKgtVdrV1RkGxPU17c8/edit?ts=5faa7049#gid=0).
