### PR TITLE
Fix adding gzip encoding only for .gz ended files

### DIFF
--- a/.github/workflows/gui-ci.yml
+++ b/.github/workflows/gui-ci.yml
@@ -478,13 +478,13 @@ jobs:
         run: >-
           aws s3 cp ./artifacts/content/assets/style.css
           s3://ensocdn/ide/${{fromJson(steps.changelog.outputs.content).version}}/style.css
-          --profile s3-upload --acl public-read --content-encoding gzip
+          --profile s3-upload --acl public-read
       - name: Upload 'ide.wasm' to CDN
         shell: bash
         run: >-
           aws s3 cp ./artifacts/content/assets/ide.wasm
           s3://ensocdn/ide/${{fromJson(steps.changelog.outputs.content).version}}/ide.wasm
-          --profile s3-upload --acl public-read --content-encoding gzip
+          --profile s3-upload --acl public-read
       - name: Upload 'wasm_imports.js.gz' to CDN
         shell: bash
         run: >-

--- a/build/workflow.js
+++ b/build/workflow.js
@@ -332,7 +332,10 @@ function uploadToCDN(...names) {
             shell: "bash",
             run: `aws s3 cp ./artifacts/content/assets/${name} `
                + `s3://ensocdn/ide/\${{fromJson(steps.changelog.outputs.content).version}}/${name} --profile `
-               + `s3-upload --acl public-read --content-encoding gzip`
+               + `s3-upload --acl public-read`
+        }
+        if (name.endsWith(".gz")) {
+            action.run += " --content-encoding gzip";
         }
         actions.push(action)
     }


### PR DESCRIPTION
### Pull Request Description
<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->
This PR updates the workflow generator and the CDN deployment workflow to set http gzip content-encoding header only for the files that end with ".gz".

### Important Notes
<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist
Please include the following checklist in your PR:

- [ ] The `CHANGELOG.md` was updated with the changes introduced in this PR.
- [ ] The documentation has been updated if necessary.
- [ ] All code conforms to the [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guide.
- [ ] All code has automatic tests where possible.
- [ ] All code has been profiled where possible.
- [ ] All code has been manually tested in the IDE.
- [ ] All code has been manually tested in the "debug/interface" scene.
- [ ] All code has been manually tested by the PR owner against our [test scenarios](https://docs.google.com/spreadsheets/d/1RatJDM_f9_3bvYhl3Bpq2d8SyKgtVdrV1RkGxPU17c8/edit?ts=5faa7049#gid=0).
- [ ] All code has been manually tested by at least one reviewer against our [test scenarios](https://docs.google.com/spreadsheets/d/1RatJDM_f9_3bvYhl3Bpq2d8SyKgtVdrV1RkGxPU17c8/edit?ts=5faa7049#gid=0).
