### PR TITLE
Correctly interpret string arguments as booleans in electron arguments.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 <br/>![Bug Fixes](/docs/assets/tags/bug_fixes.svg)
 
+- [Fix some internal settings not being applied correctly in the IDE][1536].
+  Some arguments were not passed correctly to the IDE leading to erroneous
+  behaviour in the electron app. This is now fixed.
+
 #### Visual Environment
 
 #### EnsoGL (rendering engine)
@@ -23,6 +27,7 @@ you can find their release notes
 [here](https://github.com/enso-org/enso/blob/main/RELEASES.md).
 
 [1511]: https://github.com/enso-org/ide/pull/1511
+[1511]: https://github.com/enso-org/ide/pull/1536
 
 <br/>
 

--- a/src/js/lib/content/src/index.js
+++ b/src/js/lib/content/src/index.js
@@ -7,6 +7,7 @@ import * as html_utils    from 'enso-studio-common/src/html_utils'
 import * as animation     from 'enso-studio-common/src/animation'
 import * as globalConfig  from '../../../../config.yaml'
 import cfg                from '../../../config'
+import assert             from "assert";
 
 
 
@@ -438,6 +439,36 @@ function ok(value) {
     return value !== null && value !== undefined
 }
 
+/// Check whether the value is a string with value `"true"`/`"false"`, if so, return the
+// appropriate boolean instead. Otherwise, return the original value.
+function tryAsBoolean(value) {
+    if (value === "true"){
+        return true
+    }
+    if (value === "false"){
+        return false
+    }
+    return value
+}
+
+/// Turn all values that have a boolean in string representation (`"true"`/`"false"`) into actual
+/// booleans (`true/`false``).
+function ensureBooleans(config) {
+    for (const key in config) {
+        config[key] = tryAsBoolean(config[key])
+    }
+}
+
+function initLogging(config) {
+    assert(typeof config.no_data_gathering == "boolean")
+    if (config.no_data_gathering ) {
+        API.remoteLog = function (_event, _data) {}
+    } else {
+        let logger = new MixpanelLogger
+        API.remoteLog = function (event,data) {logger.log(event,data)}
+    }
+}
+
 /// Main entry point. Loads WASM, initializes it, chooses the scene to run.
 API.main = async function (inputConfig) {
     let defaultConfig = {
@@ -451,14 +482,10 @@ API.main = async function (inputConfig) {
     let urlParams = new URLSearchParams(window.location.search);
     let urlConfig = Object.fromEntries(urlParams.entries())
     let config    = Object.assign(defaultConfig,inputConfig,urlConfig)
+    ensureBooleans(config)
     API[globalConfig.windowAppScopeConfigName] = config
 
-    if (config.no_data_gathering) {
-        API.remoteLog = function (_event, _data) {}
-    } else {
-        let logger = new MixpanelLogger
-        API.remoteLog = function (event,data) {logger.log(event,data)}
-    }
+    initLogging(config)
 
     window.setInterval(() =>{API.remoteLog("alive");}, ALIVE_LOG_INTERVAL)
     //Build data injected during the build process. See `webpack.config.js` for the source.

--- a/src/js/lib/content/src/index.js
+++ b/src/js/lib/content/src/index.js
@@ -441,7 +441,7 @@ function ok(value) {
 
 /// Check whether the value is a string with value `"true"`/`"false"`, if so, return the
 // appropriate boolean instead. Otherwise, return the original value.
-function tryAsBoolean(value) {
+function parseBooleanOrLeaveAsIs(value) {
     if (value === "true"){
         return true
     }
@@ -453,9 +453,9 @@ function tryAsBoolean(value) {
 
 /// Turn all values that have a boolean in string representation (`"true"`/`"false"`) into actual
 /// booleans (`true/`false``).
-function ensureBooleans(config) {
+function parseAllBooleans(config) {
     for (const key in config) {
-        config[key] = tryAsBoolean(config[key])
+        config[key] = parseBooleanOrLeaveAsIs(config[key])
     }
 }
 
@@ -482,7 +482,7 @@ API.main = async function (inputConfig) {
     let urlParams = new URLSearchParams(window.location.search);
     let urlConfig = Object.fromEntries(urlParams.entries())
     let config    = Object.assign(defaultConfig,inputConfig,urlConfig)
-    ensureBooleans(config)
+    parseAllBooleans(config)
     API[globalConfig.windowAppScopeConfigName] = config
 
     initLogging(config)


### PR DESCRIPTION
### Pull Request Description
Previously arguments were passed to the main function as strings when using the electron app, or as booleans when using the development environment. Since `false` is a truthy value that was not further checked, this lead to wrong settings. 
This PR adds a conversion of `true` and `false` to their boolean values, and adds an assertion that ensures that arguments are actually booleans. 

### Checklist
Please include the following checklist in your PR:

- [x] The `CHANGELOG.md` was updated with the changes introduced in this PR.
- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guide.
- [ ] ~All code has automatic tests where possible.~
- [ ] ~All code has been profiled where possible.~
- [x] All code has been manually tested in the IDE.
- [ ] ~All code has been manually tested in the "debug/interface" scene.~
- [x] All code has been manually tested by the PR owner against our [test scenarios](https://docs.google.com/spreadsheets/d/1RatJDM_f9_3bvYhl3Bpq2d8SyKgtVdrV1RkGxPU17c8/edit?ts=5faa7049#gid=0).
- [ ] All code has been manually tested by at least one reviewer against our [test scenarios](https://docs.google.com/spreadsheets/d/1RatJDM_f9_3bvYhl3Bpq2d8SyKgtVdrV1RkGxPU17c8/edit?ts=5faa7049#gid=0).
