### PR TITLE
Fix zooming with a scroll wheel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,10 @@ these updates be shipped in a stable release before the end of the year.
 
 #### Visual Environment
 
-- [New look of open project dialog.][1700]. Now it has "Open project" title on
+- [New look of open project dialog.][1700] Now it has "Open project" title on
   the top.
+- [Better zooming.][1738] Zooming in with a mouse wheel uses a more comfortable
+  step size. Previously, it jumped to the maximum zoom level in a single step.
 
 #### Enso Compiler
 

--- a/src/rust/ensogl/lib/core/src/display/navigation/navigator.rs
+++ b/src/rust/ensogl/lib/core/src/display/navigation/navigator.rs
@@ -97,7 +97,7 @@ impl NavigatorModel {
             // The direction in which we zoom. We negate x and y, because this vector points behind
             // the camera: When we get a positive scroll input, we want to move the camera
             // backwards, away from the mouse cursor.
-            let direction = Vector3(-focus_at_dist_1.x,-focus_at_dist_1.y,1.0);
+            let direction = Vector3(focus_at_dist_1.x,focus_at_dist_1.y,-1.0);
 
             let current_position = simulator.target_value();
             // We need to take the exponent because we do multiply `zoom_factor` onto the z
@@ -107,7 +107,7 @@ impl NavigatorModel {
             let zoom_factor      = zoom.amount.exp2();
             let new_z            = current_position.z * zoom_factor;
             let new_z            = new_z.max(camera.clipping().near + min_zoom).min(max_zoom);
-            let zoom_distance    = new_z - current_position.z;
+            let zoom_distance    = current_position.z - new_z;
             let zoom_delta       = direction * zoom_distance;
             let new_position     = current_position + zoom_delta;
 


### PR DESCRIPTION
### Pull Request Description
<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->
This fixes issue #1613 by changing the equations used to calculate the zoom amount. Zooming with a scroll wheel, which scrolls in big individual steps, will behave more appropriately and consistently with zooming on a touch pad or a stepless scroll wheel.

### Important Notes
<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist
Please include the following checklist in your PR:

- [x] The `CHANGELOG.md` was updated with the changes introduced in this PR.
- [ ] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guide.
- [ ] All code has automatic tests where possible.
- [ ] All code has been profiled where possible.
- [x] All code has been manually tested in the IDE.
- [x] All code has been manually tested in the "debug/interface" scene.
- [x] All code has been manually tested by the PR owner against our [test scenarios](https://docs.google.com/spreadsheets/d/1RatJDM_f9_3bvYhl3Bpq2d8SyKgtVdrV1RkGxPU17c8/edit?ts=5faa7049#gid=0).
- [ ] All code has been manually tested by at least one reviewer against our [test scenarios](https://docs.google.com/spreadsheets/d/1RatJDM_f9_3bvYhl3Bpq2d8SyKgtVdrV1RkGxPU17c8/edit?ts=5faa7049#gid=0).
