### PR TITLE
Avoid error during initialization of histograms and scatterplots

### DIFF
--- a/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/histogram.js
+++ b/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/histogram.js
@@ -44,6 +44,7 @@ class Histogram extends Visualization {
     constructor(data) {
         super(data)
         this.setPreprocessor('here.process_to_json_text', 'Standard.Visualization.Histogram')
+        this._dataBins = []
     }
 
     onDataReceived(data) {

--- a/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/scatterPlot.js
+++ b/src/rust/ide/view/graph-editor/src/builtin/visualization/java_script/scatterPlot.js
@@ -50,6 +50,12 @@ class ScatterPlot extends Visualization {
     constructor(data) {
         super(data)
         this.setPreprocessor('here.process_to_json_text', 'Standard.Visualization.Scatter_Plot')
+        this.dataPoints = []
+        this.axis = {
+            x: { scale: LINEAR_SCALE },
+            y: { scale: LINEAR_SCALE },
+        }
+        this.points = { labels: VISIBLE_POINTS }
     }
 
     /**


### PR DESCRIPTION
### Pull Request Description
<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->
This fixes issue #1746 and a similar bug for histograms.

The problem was that `setSize` used attributes that were only initialized by `onDataReceived`. But `setSize` was called first. Now, we initialize those attributes with default values in the constructor.

### Important Notes
<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist
Please include the following checklist in your PR:

- [ ] The `CHANGELOG.md` was updated with the changes introduced in this PR.
- [ ] The documentation has been updated if necessary.
- [ ] All code conforms to the [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guide.
- [ ] All code has automatic tests where possible.
- [ ] All code has been profiled where possible.
- [ ] All code has been manually tested in the IDE.
- [ ] All code has been manually tested in the "debug/interface" scene.
- [ ] All code has been manually tested by the PR owner against our [test scenarios](https://airtable.com/shr7KPRypRpanF7TO).
- [ ] All code has been manually tested by at least one reviewer against our [test scenarios](https://airtable.com/shr7KPRypRpanF7TO).

[ci no changelog needed]