### PR TITLE
FRP with cycles

### DIFF
--- a/src/rust/ensogl/lib/components/src/drop_down_menu.rs
+++ b/src/rust/ensogl/lib/components/src/drop_down_menu.rs
@@ -274,9 +274,9 @@ impl DropDownMenu {
 
             eval_ hide_menu (model.selection_menu.deselect_entries.emit(()));
 
-            frp.source.menu_visible <+ hide_menu.constant(false);
-            frp.source.menu_visible <+ show_menu.constant(true);
-            frp.source.menu_closed  <+ hide_menu;
+            menu_visible            <- bool(&hide_menu,&show_menu).on_change();
+            frp.source.menu_visible <+ menu_visible;
+            frp.source.menu_closed  <+ menu_visible.on_false();
 
             target_height <- all_with(&frp.output.menu_visible,&model.selection_menu.frp.set_entries,
                 f!([](visible,entries) {
@@ -347,12 +347,12 @@ impl DropDownMenu {
             });
 
 
-           // === Close Menu ===
+            // === Close Menu ===
 
-           mouse_down        <- mouse.down.constant(());
-           mouse_down_remote <- mouse_down.gate_not(&icon_hovered);
-           dismiss_menu      <- any(&frp.hide_selection_menu,&mouse_down_remote);
-           eval_ dismiss_menu ( hide_menu.emit(()) );
+            mouse_down        <- mouse.down.constant(());
+            mouse_down_remote <- mouse_down.gate_not(&icon_hovered);
+            dismiss_menu      <- any(&frp.hide_selection_menu,&mouse_down_remote);
+            eval_ dismiss_menu ( hide_menu.emit(()) );
         }
 
         // FIXME : StyleWatch is unsuitable here, as it was designed as an internal tool for

--- a/src/rust/ide/src/ide/integration/project.rs
+++ b/src/rust/ide/src/ide/integration/project.rs
@@ -319,7 +319,7 @@ impl Integration {
 
         let file_browser = &model.view.open_dialog().file_browser;
         let project_list = &model.view.open_dialog().project_list;
-        frp::extend! { TRACE_ALL network
+        frp::extend! { network
             let chosen_project = project_list.chosen_entry.clone_ref();
             let file_chosen    = file_browser.entry_chosen.clone_ref();
             project_chosen     <- chosen_project.filter_map(|p| *p);

--- a/src/rust/ide/view/graph-editor/src/component/breadcrumbs/project_name.rs
+++ b/src/rust/ide/view/graph-editor/src/component/breadcrumbs/project_name.rs
@@ -286,8 +286,6 @@ impl ProjectName {
             });
             frp.source.edit_mode <+ start_editing.to_true();
 
-            outside_press <- any(&frp.outside_press,&frp.deselect);
-
 
             // === Text Area ===
 
@@ -299,21 +297,20 @@ impl ProjectName {
 
             // === Input Commands ===
 
-            eval_ frp.input.cancel_editing(model.reset_name());
+            eval_ frp.input.cancel_editing  (model.reset_name());
             eval  frp.input.set_name((name) {model.rename(name)});
             frp.output.source.name <+ frp.input.set_name;
 
 
             // === Commit ===
 
-            do_commit <- any(&frp.commit,&outside_press).gate(&frp.output.edit_mode);
+            do_commit <- any(&frp.commit,&frp.outside_press).gate(&frp.output.edit_mode);
             commit_text <- text_content.sample(&do_commit);
             frp.output.source.name <+ commit_text;
             eval commit_text((text) model.commit(text));
             on_commit <- commit_text.constant(());
 
-            end_edit_mode <- any(&on_commit,&on_deselect);
-            frp.output.source.edit_mode <+ end_edit_mode.to_false();
+            frp.output.source.edit_mode <+ on_deselect.to_false();
 
 
             // === Selection ===
@@ -321,7 +318,7 @@ impl ProjectName {
             eval_ frp.select( animations.color.set_target_value(selected_color) );
             frp.output.source.selected <+ frp.select.to_true();
 
-            set_inactive <- any3(&frp.deselect,&end_edit_mode,&outside_press);
+            set_inactive <- any(&frp.deselect,&on_commit);
             eval_ set_inactive ([text,animations]{
                 text.set_focus(false);
                 text.remove_all_cursors();

--- a/src/rust/ide/view/src/project.rs
+++ b/src/rust/ide/view/src/project.rs
@@ -210,7 +210,6 @@ impl Model {
             }
             _ => {
                 self.searcher.hide();
-                self.searcher.clear_actions();
             }
         }
     }

--- a/src/rust/ide/view/src/searcher.rs
+++ b/src/rust/ide/view/src/searcher.rs
@@ -223,10 +223,12 @@ impl View {
             eval frp.hide     ((()) height.set_target_value(-list_view::SHADOW_PX));
 
             is_selected               <- model.list.selected_entry.map(|e| e.is_some());
+            is_enabled                <- bool(&frp.hide,&frp.show);
+            is_entry_enabled          <- is_selected && is_enabled;
             displayed_doc             <- model.list.selected_entry.map(f!((id) model.docs_for(*id)));
             opt_picked_entry          <- model.list.selected_entry.sample(&frp.use_as_suggestion);
-            source.used_as_suggestion <+ opt_picked_entry.gate(&is_selected);
-            source.editing_committed  <+ model.list.chosen_entry.gate(&is_selected);
+            source.used_as_suggestion <+ opt_picked_entry.gate(&is_entry_enabled);
+            source.editing_committed  <+ model.list.chosen_entry.gate(&is_entry_enabled);
 
             eval displayed_doc ((data) model.documentation.frp.display_documentation(data));
         };

--- a/src/rust/ide/view/src/status_bar.rs
+++ b/src/rust/ide/view/src/status_bar.rs
@@ -166,7 +166,7 @@ impl Model {
         let label           = text::Area::new(app);
         let events          = default();
         let processes       = default();
-        let next_process_id = default();
+        let next_process_id = Rc::new(RefCell::new(process::Id(1)));
         let camera          = scene.camera();
 
         scene.layers.panel.add_exclusive(&background);
@@ -279,7 +279,9 @@ impl View {
             _process_finished <- frp.finish_process.filter_map(f!((id)
                 model.finish_process(*id).as_some(*id)
             ));
-            displayed_process_finished <- frp.finish_process.all(&frp.output.displayed_process).filter(|(fin,dis)| dis.contains(fin));
+            displayed_process_finished <- frp.finish_process
+                .map2(&frp.output.displayed_process, |fin,dis|(*fin,*dis))
+                .filter(|(fin,dis)| dis.contains(fin));
 
             label_after_adding_event <- frp.add_event.map(
                 |label| AsRef::<ImString>::as_ref(label).clone_ref()

--- a/src/rust/lib/frp/src/nodes.rs
+++ b/src/rust/lib/frp/src/nodes.rs
@@ -955,6 +955,7 @@ impl<T:EventOutput> OwnedTrace<T> {
 impl<T:EventOutput> stream::EventConsumer<Output<T>> for OwnedTrace<T> {
     fn on_event(&self, stack:CallStack, event:&Output<T>) {
         DEBUG!("[FRP] {self.label()}: {event:?}");
+        DEBUG!("[FRP] {stack}");
         self.emit_event(stack,event);
     }
 }


### PR DESCRIPTION
[ci skip changelog]

### Pull Request Description

Before, the event loops were forbidden in FRP as they were likely to be infinite. However, during development of Node Searcher 2.0 new cases appeared, where loops can be desirable: for example, recursive requesting for the directory content.

This PR make FRP loops allowed, and only checks the number of the node's recursive evaluations: if it exceeds the appointed limit, the event propagation will be stopped and warning will be printed. 

### Important Notes
<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist
Please include the following checklist in your PR:

- ~~[ ] The `CHANGELOG.md` was updated with the changes introduced in this PR.~~
- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guide.
- [x] All code has automatic tests where possible.
- [x] All code has been profiled where possible.
- [x] All code has been manually tested in the IDE.
- [x] All code has been manually tested in the "debug/interface" scene.
- [x] All code has been manually tested by the PR owner against our [test scenarios](https://airtable.com/shr7KPRypRpanF7TO).
- [ ] All code has been manually tested by at least one reviewer against our [test scenarios](https://airtable.com/shr7KPRypRpanF7TO).
