### PR TITLE
Add "All Search Result" category for showing filtering output.

### DIFF
--- a/src/rust/ide/src/controller/searcher.rs
+++ b/src/rust/ide/src/controller/searcher.rs
@@ -522,7 +522,7 @@ impl Searcher {
         Ok(ret)
     }
 
-    /// Return true if user is currently filtering entries (the input has non-empty _pattern_ part.
+    /// Return true if user is currently filtering entries (the input has non-empty _pattern_ part).
     pub fn is_filtering(&self) -> bool {
         !self.data.borrow().input.pattern.is_empty()
     }
@@ -1510,7 +1510,8 @@ pub mod test {
     #[wasm_bindgen_test]
     fn loading_list() {
         let Fixture{mut test,searcher,entry1,entry9,..} = Fixture::new_custom(|data,client| {
-            // entry with id 99999 does not exist, so only two actions from suggestions will be
+            // entry with id 99999 does not exist, so only two actions from suggestions db should be
+            // displayed in searcher.
             data.expect_completion(client,None,None,&[1,99999,9]);
         });
 

--- a/src/rust/ide/src/controller/searcher.rs
+++ b/src/rust/ide/src/controller/searcher.rs
@@ -522,6 +522,11 @@ impl Searcher {
         Ok(ret)
     }
 
+    /// Return true if user is currently filtering entries (the input has non-empty _pattern_ part.
+    pub fn is_filtering(&self) -> bool {
+        !self.data.borrow().input.pattern.is_empty()
+    }
+
     /// Subscribe to controller's notifications.
     pub fn subscribe(&self) -> Subscriber<Notification> {
         self.notifier.subscribe()
@@ -898,7 +903,7 @@ impl Searcher {
     ) -> FallibleResult<action::List> {
         let creating_new_node             = matches!(self.mode.deref(), Mode::NewNode{..});
         let should_add_additional_entries = creating_new_node && self.this_arg.is_none();
-        let mut actions                   = action::ListBuilder::default();
+        let mut actions                   = action::ListWithSearchResultBuilder::new();
         let (libraries_icon,default_icon) = action::hardcoded::ICONS.with(|i|
             (i.libraries.clone_ref(),i.default.clone_ref())
         );
@@ -1505,7 +1510,8 @@ pub mod test {
     #[wasm_bindgen_test]
     fn loading_list() {
         let Fixture{mut test,searcher,entry1,entry9,..} = Fixture::new_custom(|data,client| {
-            data.expect_completion(client,None,None,&[1,5,9]);
+            // entry with id 99999 does not exist, so only two actions from suggestions will be
+            data.expect_completion(client,None,None,&[1,99999,9]);
         });
 
         let mut subscriber = searcher.subscribe();
@@ -1513,7 +1519,9 @@ pub mod test {
         assert!(searcher.actions().is_loading());
         test.run_until_stalled();
         let list = searcher.actions().list().unwrap().to_action_vec();
-        assert_eq!(list.len(), 4); // we include two mocked entries
+        // There are 8 entries, because: 2 were returned from `completion` method, two are mocked,
+        // and all of these are repeasted in "All Search Result" category.
+        assert_eq!(list.len(), 8);
         assert_eq!(list[2], Action::Suggestion(action::Suggestion::FromDatabase(entry1)));
         assert_eq!(list[3], Action::Suggestion(action::Suggestion::FromDatabase(entry9)));
         let notification = subscriber.next().boxed_local().expect_ready();

--- a/src/rust/ide/src/controller/searcher/action.rs
+++ b/src/rust/ide/src/controller/searcher/action.rs
@@ -439,30 +439,33 @@ impl<'a> CategoryBuilder<'a> {
 
 // === ListWithSearchResultBuilder ===
 
-// The Actions list builder which adds a special "All search result" category.
+/// The Actions list builder which adds a special "All search result" category: it will contain
+/// all entries (regardless of their categories) and is designed to be displayed upon filtering.
 #[derive(Debug,Default)]
 pub struct ListWithSearchResultBuilder {
     internal               : ListBuilder,
-    search_result_category : Option<CategoryId>,
+    search_result_category : CategoryId,
 }
 
 impl ListWithSearchResultBuilder {
-    pub fn new_with_search_result() -> Self {
+    /// Constructor.
+    pub fn new() -> Self {
+        let icon = hardcoded::ICONS.with(|icons| icons.search_result.clone_ref());
         let mut internal           = ListBuilder::default();
-        let mut search_result_root = internal.add_root_category("All Search Result");
-        let search_result_category = search_result_root.add_category("All Search Result");
-        let search_result_category = Some(search_result_category.category_id);
+        let mut search_result_root = internal.add_root_category("All Search Result",icon.clone_ref());
+        let search_result_category = search_result_root.add_category("All Search Result",icon);
+        let search_result_category = search_result_category.category_id;
         Self {internal,search_result_category}
     }
 
-    pub fn new_without_search_result() -> Self {
-        default()
+    /// Add the new root category with a given name. The returned builder should be used to add
+    /// sub-categories to it.
+    pub fn add_root_category
+    (&mut self, name: impl Into<Cow<'static,str>>, icon:ImString) -> RootCategoryBuilder {
+        self.internal.add_root_category(name,icon)
     }
 
-    pub fn add_root_category(&mut self, name: impl Into<Cow<'static,str>>) -> RootCategoryBuilder {
-        self.internal.add_root_category(name)
-    }
-
+    /// Consumes self returning built list.
     pub fn build(self) -> List {
         let search_results = self.make_searcher_result_entries();
         // The entries will be sorted, so it is no problem in pushing search results at the end.
@@ -471,12 +474,11 @@ impl ListWithSearchResultBuilder {
     }
 
     fn make_searcher_result_entries(&self) -> Vec<ListEntry> {
-        if let Some(category) = self.search_result_category {
-            self.internal.built_list.entries.borrow().iter().map(|entry| {
-                let match_info = MatchInfo::Matches {subsequence:default()};
-                let action     = entry.action.clone_ref();
-                ListEntry {category,match_info,action}
-            }).collect()
-        } else { default() }
+        self.internal.built_list.entries.borrow().iter().map(|entry| {
+            let match_info = MatchInfo::Matches {subsequence:default()};
+            let action     = entry.action.clone_ref();
+            let category   = self.search_result_category;
+            ListEntry {category,match_info,action}
+        }).collect()
     }
 }

--- a/src/rust/ide/src/controller/searcher/action/hardcoded.rs
+++ b/src/rust/ide/src/controller/searcher/action/hardcoded.rs
@@ -35,10 +35,10 @@ thread_local! {
     pub static ICONS:Icons = Icons {
         search_result : ImString::new("search_result"),
         data_science  : ImString::new("data_science"),
-        input_output  : ImString::new("input_output"),
+        input_output  : ImString::new("io"),
         text          : ImString::new("text"),
-        number_input  : ImString::new("data_input"),
-        text_input    : ImString::new("data_input"),
+        number_input  : ImString::new("number_input"),
+        text_input    : ImString::new("text_input"),
         data_input    : ImString::new("data_input"),
         libraries     : ImString::new("libraries"),
         default       : ImString::new("default"),

--- a/src/rust/ide/src/controller/searcher/action/hardcoded.rs
+++ b/src/rust/ide/src/controller/searcher/action/hardcoded.rs
@@ -19,27 +19,29 @@ use crate::model::module::MethodId;
 #[allow(missing_docs)]
 #[derive(Clone,CloneRef,Debug,Default)]
 pub struct Icons {
-    pub data_science : ImString,
-    pub input_output : ImString,
-    pub text         : ImString,
-    pub number_input : ImString,
-    pub text_input   : ImString,
-    pub data_input   : ImString,
-    pub libraries    : ImString,
-    pub default      : ImString,
+    pub search_result : ImString,
+    pub data_science  : ImString,
+    pub input_output  : ImString,
+    pub text          : ImString,
+    pub number_input  : ImString,
+    pub text_input    : ImString,
+    pub data_input    : ImString,
+    pub libraries     : ImString,
+    pub default       : ImString,
 }
 
 thread_local! {
     /// A set of hardcoded icon names, to be used when creating hardcoded categories and actions.
     pub static ICONS:Icons = Icons {
-        data_science : ImString::new("DataScience"),
-        input_output : ImString::new("Text"),
-        text         : ImString::new("Text"),
-        number_input : ImString::new("DataInput"),
-        text_input   : ImString::new("DataInput"),
-        data_input   : ImString::new("DataInput"),
-        libraries    : ImString::new("Libraries"),
-        default      : ImString::new("Default"),
+        search_result : ImString::new("search_result"),
+        data_science  : ImString::new("data_science"),
+        input_output  : ImString::new("input_output"),
+        text          : ImString::new("text"),
+        number_input  : ImString::new("data_input"),
+        text_input    : ImString::new("data_input"),
+        data_input    : ImString::new("data_input"),
+        libraries     : ImString::new("libraries"),
+        default       : ImString::new("default"),
     };
 }
 

--- a/src/rust/ide/src/ide/integration/project.rs
+++ b/src/rust/ide/src/ide/integration/project.rs
@@ -1067,16 +1067,17 @@ impl Model {
         let maybe_searcher = self.searcher.borrow();
         let maybe_actions  = maybe_searcher.as_ref().map(|s| s.actions());
         let maybe_list     = maybe_actions.as_ref().and_then(|actions| actions.list());
-        let is_filtering   = maybe_searcher.as_ref().map_or(false, |s| s.is_filtering());
+        // TODO[ao] uncomment once new searcher gui will be implemented.
+        //     (https://github.com/enso-org/ide/issues/1681)
+        // let is_filtering   = maybe_searcher.as_ref().map_or(false, |s| s.is_filtering());
         if let Some(list)  = maybe_list {
             match crumbs.len() {
                 0 => {
                     // We skip the first "All Search Result" category if we're not currently
                     // filtering
-                    // TODO[ao] change first 1 with 0 once new searcher gui will be available
-                    //     (https://github.com/enso-org/ide/issues/1681)
-                    let skipped_categories = if is_filtering {1} else {1};
-                    // this one ------------------------------^
+                    // TODO[ao] uncomment the `if` version once new searcher gui will be
+                    //     implemented. (https://github.com/enso-org/ide/issues/1681)
+                    let skipped_categories = /*if is_filtering {0} else {1};*/ 1;
                     list.root_categories().skip(skipped_categories).map(|(id,cat)|
                         (id,ide_view::searcher::new::Entry {
                             label     : cat.name.to_string().into(),

--- a/src/rust/ide/src/ide/integration/project.rs
+++ b/src/rust/ide/src/ide/integration/project.rs
@@ -1073,7 +1073,10 @@ impl Model {
                 0 => {
                     // We skip the first "All Search Result" category if we're not currently
                     // filtering
-                    let skipped_categories = if is_filtering {0} else {1};
+                    // TODO[ao] change first 1 with 0 once new searcher gui will be available
+                    //     (https://github.com/enso-org/ide/issues/1681)
+                    let skipped_categories = if is_filtering {1} else {1};
+                    // this one ------------------------------^
                     list.root_categories().skip(skipped_categories).map(|(id,cat)|
                         (id,ide_view::searcher::new::Entry {
                             label     : cat.name.to_string().into(),

--- a/src/rust/ide/src/ide/integration/project.rs
+++ b/src/rust/ide/src/ide/integration/project.rs
@@ -1064,20 +1064,15 @@ impl Model {
 impl Model {
     pub fn get_category_content
     (&self, crumbs:&[usize]) -> Vec<(usize,ide_view::searcher::new::Entry)> {
-        let maybe_searcher = self.searcher.borrow();
-        let maybe_actions  = maybe_searcher.as_ref().map(|s| s.actions());
-        let maybe_list     = maybe_actions.as_ref().and_then(|actions| actions.list());
-        // TODO[ao] uncomment once new searcher gui will be implemented.
-        //     (https://github.com/enso-org/ide/issues/1681)
-        // let is_filtering   = maybe_searcher.as_ref().map_or(false, |s| s.is_filtering());
+        let maybe_actions = self.searcher.borrow().as_ref().map(controller::Searcher::actions);
+        let is_filtering  = self.searcher.borrow().contains_if(controller::Searcher::is_filtering);
+        let maybe_list    = maybe_actions.as_ref().and_then(|actions| actions.list());
         if let Some(list)  = maybe_list {
             match crumbs.len() {
                 0 => {
                     // We skip the first "All Search Result" category if we're not currently
                     // filtering
-                    // TODO[ao] uncomment the `if` version once new searcher gui will be
-                    //     implemented. (https://github.com/enso-org/ide/issues/1681)
-                    let skipped_categories = /*if is_filtering {0} else {1};*/ 1;
+                    let skipped_categories = if is_filtering {0} else {1};
                     list.root_categories().skip(skipped_categories).map(|(id,cat)|
                         (id,ide_view::searcher::new::Entry {
                             label     : cat.name.to_string().into(),
@@ -1967,7 +1962,11 @@ impl SuggestionsProviderForView {
 
 impl list_view::entry::ModelProvider<GlyphHighlightedLabel> for SuggestionsProviderForView {
     fn entry_count(&self) -> usize {
-        self.actions.matching_count()
+        // TODO[ao] Because of "All Search Results" category, the actions on list are duplicated.
+        //     But we don't want to display duplicates on the old searcher list. To be fixed/removed
+        //     once new searcher GUI will be implemented
+        //     (https://github.com/enso-org/ide/issues/1681)
+        self.actions.matching_count() / 2
     }
 
     fn get(&self, id: usize) -> Option<list_view::entry::GlyphHighlightedLabelModel> {


### PR DESCRIPTION
[ci changelog not needed]

### Pull Request Description
This PR makes the list with all entries have a special category containing all entries, displayed only when user is filtering output. 

### Important Notes
<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist
Please include the following checklist in your PR:

- ~~[ ] The `CHANGELOG.md` was updated with the changes introduced in this PR.~~
- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guide.
- [x] All code has automatic tests where possible.
- [x] All code has been profiled where possible.
- [x] All code has been manually tested in the IDE.
- ~~[ ] All code has been manually tested in the "debug/interface" scene.~~
- [x] All code has been manually tested by the PR owner against our [test scenarios](https://airtable.com/shr7KPRypRpanF7TO).
- [ ] All code has been manually tested by at least one reviewer against our [test scenarios](https://airtable.com/shr7KPRypRpanF7TO).
