### PR TITLE
Get engine version from config

### DIFF
--- a/build/release.js
+++ b/build/release.js
@@ -5,6 +5,7 @@ const fss    = require('fs')
 const path   = require('path')
 const paths  = require('./paths')
 const semver = require('semver')
+const config = require('../config')
 
 
 
@@ -14,6 +15,7 @@ const semver = require('semver')
 
 const CHANGELOG_FILE_NAME = 'CHANGELOG.md'
 const CHANGELOG_FILE      = path.join(paths.root,CHANGELOG_FILE_NAME)
+const ENGINE_VERSION      = config.engineVersion
 
 
 
@@ -190,4 +192,4 @@ function currentVersion() {
 // === Exports ===
 // ===============
 
-module.exports = {Version,NextReleaseVersion,changelog,currentVersion}
+module.exports = {ENGINE_VERSION,Version,NextReleaseVersion,changelog,currentVersion}

--- a/config.json
+++ b/config.json
@@ -1,4 +1,5 @@
 {
     "minimumSupportedVersion": "2.0.0-alpha.6",
+    "minimumSupportedEdition": "2021.18",
     "engineVersion": "0.2.30"
 }

--- a/config.json
+++ b/config.json
@@ -1,3 +1,4 @@
 {
-  "minimumSupportedVersion": "2.0.0-alpha.6"
+    "minimumSupportedVersion": "2.0.0-alpha.6",
+    "engineVersion": "0.2.30"
 }

--- a/src/js/lib/client/tasks/signArchives.js
+++ b/src/js/lib/client/tasks/signArchives.js
@@ -16,13 +16,11 @@
 const path = require('path')
 const child_process = require('child_process')
 const { dist } = require('../../../../../build/paths')
+const { ENGINE_VERSION } = require('../../../../../build/release')
 
 const contentRoot = path.join(dist.root, 'client', 'mac', 'Enso.app', 'Contents')
 const resRoot = path.join(contentRoot, 'Resources')
 
-// TODO: Refactor this once we have a better wau to get the used engine version.
-//  See the tracking issue for more information https://github.com/enso-org/ide/issues/1359
-const ENGINE = '0.2.30'
 const ID = '"Developer ID Application: New Byte Order Sp. z o. o. (NM77WTZJFQ)"'
 // Placeholder name for temporary archives.
 const tmpArchive = 'temporary_archive.zip'
@@ -110,7 +108,7 @@ function signArchive(archivePath, archiveName, binPaths) {
 const toSign = [
     {
         jarDir:
-            `enso/dist/${ENGINE}/lib/Standard/Database/${ENGINE}/polyglot/java`,
+            `enso/dist/${ENGINE_VERSION}/lib/Standard/Database/${ENGINE_VERSION}/polyglot/java`,
         jarName: 'sqlite-jdbc-3.34.0.jar',
         jarContent: [
             'org/sqlite/native/Mac/aarch64/libsqlitejdbc.jnilib',
@@ -119,7 +117,7 @@ const toSign = [
     },
     {
         jarDir:
-            `enso/dist/${ENGINE}/component`,
+            `enso/dist/${ENGINE_VERSION}/component`,
         jarName: 'runner.jar',
         jarContent: [
             'org/sqlite/native/Mac/x86_64/libsqlitejdbc.jnilib',

--- a/src/js/lib/project-manager/src/build.ts
+++ b/src/js/lib/project-manager/src/build.ts
@@ -13,6 +13,8 @@ import * as unzipper from 'unzipper'
 import * as url from 'url'
 // @ts-ignore
 import * as paths from './../../../../../build/paths'
+// @ts-ignore
+import { ENGINE_VERSION } from './../../../../../build/release'
 import { IncomingMessage } from 'http'
 const fs = fss.promises
 
@@ -132,14 +134,14 @@ async function download_project_manager(file_url: string, overwrite: boolean): P
         )
     } else {
         await fs.mkdir(download_dir, { recursive: true })
-    
+
         const parsed = url.parse(file_url)
         const options = {
             host: parsed.host,
             port: 80,
             path: parsed.pathname,
         }
-    
+
         const target_file = fss.createWriteStream(file_path)
         const progress_indicator = new DownloadProgressIndicator()
         await new Promise((resolve, reject) =>
@@ -168,14 +170,11 @@ async function download_project_manager(file_url: string, overwrite: boolean): P
 // ============
 
 async function main() {
-    // `version` MUST be synchronized with `ENGINE` constant in src/js/lib/client/tasks/signArchives.js.
-    // Also it is usually a good idea to synchronize it with `ENGINE_VERSION_FOR_NEW_PROJECTS` in
-    // src/rust/ide/src/controller/project.rs. See also https://github.com/enso-org/ide/issues/1359
     const buildInfo: BuildInfo = {
-        version: '0.2.30',
+        version: ENGINE_VERSION,
         target: (await get_build_config()).target,
     }
-    
+
     // The file at path `buildInfoFile` should always contain the build info of the project manager
     // that is currently installed in the dist directory. We read the file if it exists and compare
     // it with the version and target platform that we need. If they already agree then the right
@@ -195,7 +194,7 @@ async function main() {
         }
     }
     if (buildInfo.version !== existing_build_info?.version ||
-        buildInfo.target  !== existing_build_info?.target) {
+        buildInfo.target !== existing_build_info?.target) {
 
         // We remove the build info file to avoid misinformation if the build is interrupted during
         // the call to `download_project_manager`.

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -1495,7 +1495,7 @@ dependencies = [
  "nalgebra 0.26.2",
  "parser",
  "regex",
- "semver",
+ "semver 1.0.4",
  "serde",
  "serde_json",
  "sha3",
@@ -2781,7 +2781,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
- "semver",
+ "semver 0.9.0",
 ]
 
 [[package]]
@@ -2854,6 +2854,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
  "semver-parser",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/src/rust/ide/Cargo.toml
+++ b/src/rust/ide/Cargo.toml
@@ -41,7 +41,7 @@ itertools = { version = "0.10.0" }
 js-sys = { version = "0.3.28" }
 mockall = { version = "0.7.1", features = ["nightly"] }
 nalgebra = { version = "0.26.1", features = ["serde-serialize"] }
-semver = { version = "0.9.0" }
+semver = { version = "1.0.0", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
 sha3 = { version = "0.8.2" }

--- a/src/rust/ide/src/controller/ide/desktop.rs
+++ b/src/rust/ide/src/controller/ide/desktop.rs
@@ -4,18 +4,18 @@
 
 use crate::prelude::*;
 
-use crate::controller::ide::API;
 use crate::controller::ide::ManagingProjectAPI;
-use crate::controller::ide::StatusNotificationPublisher;
 use crate::controller::ide::Notification;
-use crate::controller::project::ENGINE_VERSION_FOR_NEW_PROJECTS;
+use crate::controller::ide::StatusNotificationPublisher;
+use crate::controller::ide::API;
+use crate::controller::project::CONFIG;
 use crate::ide::initializer;
 use crate::notification;
 
 use enso_protocol::project_manager;
 use enso_protocol::project_manager::MissingComponentAction;
-use enso_protocol::project_manager::ProjectName;
 use enso_protocol::project_manager::ProjectMetadata;
+use enso_protocol::project_manager::ProjectName;
 use parser::Parser;
 
 
@@ -98,11 +98,14 @@ impl ManagingProjectAPI for Handle {
             let with_suffix           = (1..).map(|i| format!("{}_{}", UNNAMED_PROJECT_NAME, i));
             let mut candidates        = std::iter::once(without_suffix).chain(with_suffix);
             // The iterator have no end, so we can safely unwrap.
-            let name    = candidates.find(|c| !names.contains(c)).unwrap();
-            let version = Some(ENGINE_VERSION_FOR_NEW_PROJECTS.to_owned());
-            let action  = MissingComponentAction::Install;
+            let name = candidates.find(|c| !names.contains(c)).unwrap();
+            let version = Some(CONFIG.engine_version_for_new_projects().to_string());
+            let action = MissingComponentAction::Install;
 
-            let create_result  = self.project_manager.create_project(&name,&version,&action).await?;
+            let create_result = self
+                .project_manager
+                .create_project(&name, &version, &action)
+                .await?;
             let new_project_id = create_result.project_id;
             let project_mgr    = self.project_manager.clone_ref();
             let new_project    = Project::new_opened(&self.logger,project_mgr,new_project_id);

--- a/src/rust/ide/src/controller/ide/desktop.rs
+++ b/src/rust/ide/src/controller/ide/desktop.rs
@@ -99,7 +99,7 @@ impl ManagingProjectAPI for Handle {
             let mut candidates        = std::iter::once(without_suffix).chain(with_suffix);
             // The iterator have no end, so we can safely unwrap.
             let name = candidates.find(|c| !names.contains(c)).unwrap();
-            let version = Some(CONFIG.engine_version_for_new_projects().to_string());
+            let version = Some(CONFIG.engine_version.to_string());
             let action = MissingComponentAction::Install;
 
             let create_result = self

--- a/src/rust/ide/src/controller/ide/desktop.rs
+++ b/src/rust/ide/src/controller/ide/desktop.rs
@@ -98,14 +98,11 @@ impl ManagingProjectAPI for Handle {
             let with_suffix           = (1..).map(|i| format!("{}_{}", UNNAMED_PROJECT_NAME, i));
             let mut candidates        = std::iter::once(without_suffix).chain(with_suffix);
             // The iterator have no end, so we can safely unwrap.
-            let name = candidates.find(|c| !names.contains(c)).unwrap();
+            let name    = candidates.find(|c| !names.contains(c)).unwrap();
             let version = Some(CONFIG.engine_version.to_string());
-            let action = MissingComponentAction::Install;
+            let action  = MissingComponentAction::Install;
 
-            let create_result = self
-                .project_manager
-                .create_project(&name, &version, &action)
-                .await?;
+            let create_result = self.project_manager.create_project(&name,&version,&action).await?;
             let new_project_id = create_result.project_id;
             let project_mgr    = self.project_manager.clone_ref();
             let new_project    = Project::new_opened(&self.logger,project_mgr,new_project_id);

--- a/src/rust/ide/src/controller/ide/desktop.rs
+++ b/src/rust/ide/src/controller/ide/desktop.rs
@@ -102,7 +102,7 @@ impl ManagingProjectAPI for Handle {
             let version = Some(CONFIG.engine_version.to_string());
             let action  = MissingComponentAction::Install;
 
-            let create_result = self.project_manager.create_project(&name,&version,&action).await?;
+            let create_result  = self.project_manager.create_project(&name,&version,&action).await?;
             let new_project_id = create_result.project_id;
             let project_mgr    = self.project_manager.clone_ref();
             let new_project    = Project::new_opened(&self.logger,project_mgr,new_project_id);

--- a/src/rust/ide/src/controller/project.rs
+++ b/src/rust/ide/src/controller/project.rs
@@ -49,7 +49,7 @@ lazy_static! {
 }
 
 /// The label of compiling stdlib message process.
-pub const COMPILING_STDLIB_LABEL: &str = "Compiling standard library. It can take up to 1 minute.";
+pub const COMPILING_STDLIB_LABEL:&str = "Compiling standard library. It can take up to 1 minute.";
 
 /// The name of the module initially opened in the project view.
 ///
@@ -244,7 +244,7 @@ impl Project {
 
     fn display_warning_on_unsupported_engine_version(&self) {
         let requirements = CONFIG.engine_version_supported();
-        let version = self.model.engine_version();
+        let version      = self.model.engine_version();
         if !requirements.matches(&version) {
             let message = format!(
                 "Unsupported Engine version. Please update edition in {} \
@@ -284,7 +284,7 @@ mod tests {
     #[test]
     fn new_project_engine_version_fills_requirements() {
         let requirements = CONFIG.engine_version_supported();
-        let version = &CONFIG.engine_version;
+        let version      = &CONFIG.engine_version;
         assert!(requirements.matches(version))
     }
 

--- a/src/rust/ide/src/controller/project.rs
+++ b/src/rust/ide/src/controller/project.rs
@@ -19,6 +19,15 @@ use parser::Parser;
 // === Constants ===
 // =================
 
+lazy_static! {
+    static ref ENGINE_VERSION: String = {
+        let global_config = include_str!("../../../../../config.json");
+        let json: serde_json::Value = serde_json::from_str(global_config).unwrap();
+        let engine_version = &json["engineVersion"];
+        engine_version.as_str().unwrap().to_string()
+    };
+}
+
 /// The label of compiling stdlib message process.
 pub const COMPILING_STDLIB_LABEL:&str = "Compiling standard library. It can take up to 1 minute.";
 
@@ -249,6 +258,11 @@ mod tests {
 
     use crate::executor::test_utils::TestWithLocalPoolExecutor;
 
+    #[test]
+    fn get_engine_version() {
+        println!("{}", ENGINE_VERSION.as_str());
+        assert!(!ENGINE_VERSION.is_empty());
+    }
 
     #[test]
     fn main_module_id_test() {

--- a/src/rust/ide/src/controller/project.rs
+++ b/src/rust/ide/src/controller/project.rs
@@ -15,30 +15,24 @@ use parser::Parser;
 use semver::{Version, VersionReq};
 use serde::{Deserialize, Serialize};
 
+
+
 /// Application config.
 #[derive(Hash, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GlobalConfig {
-    /// The minimum supported IDE version.
-    pub minimum_supported_version: String,
-
     /// The minimum edition that is guaranteed to work with the IDE.
     pub minimum_supported_edition: String,
 
     /// The engine version used in projects created in IDE.
-    pub engine_version: String,
+    pub engine_version: Version,
 }
 
 impl GlobalConfig {
     /// The requirements for Engine's version, in format understandable by
     /// [`semver::VersionReq::parse`].
     pub fn engine_version_supported(&self) -> VersionReq {
-        VersionReq::parse(format!("^{}", self.engine_version).as_str()).unwrap()
-    }
-
-    /// The engine version used in projects created in IDE.
-    pub fn engine_version_for_new_projects(&self) -> Version {
-        Version::parse(&self.engine_version).unwrap()
+        VersionReq::parse(format!("^{}", self.engine_version.to_string()).as_str()).unwrap()
     }
 }
 
@@ -290,8 +284,8 @@ mod tests {
     #[test]
     fn new_project_engine_version_fills_requirements() {
         let requirements = CONFIG.engine_version_supported();
-        let version = CONFIG.engine_version_for_new_projects();
-        assert!(requirements.matches(&version))
+        let version = &CONFIG.engine_version;
+        assert!(requirements.matches(version))
     }
 
     #[wasm_bindgen_test]

--- a/src/rust/ide/src/controller/project.rs
+++ b/src/rust/ide/src/controller/project.rs
@@ -176,6 +176,7 @@ impl Project {
         self.display_warning_on_unsupported_engine_version();
 
 
+
         Ok(InitializationResult {main_module_text,main_module_model,main_graph})
     }
 }
@@ -246,12 +247,8 @@ impl Project {
         let requirements = CONFIG.engine_version_supported();
         let version      = self.model.engine_version();
         if !requirements.matches(&version) {
-            let message = format!(
-                "Unsupported Engine version. Please update edition in {} \
-                to {}.",
-                package_yaml_path(&self.model.name()),
-                CONFIG.minimum_supported_edition,
-            );
+            let message = format!("Unsupported Engine version. Please update edition in {} \
+                to {}.",package_yaml_path(&self.model.name()),CONFIG.minimum_supported_edition);
             self.status_notifications.publish_event(message);
         }
     }

--- a/src/rust/ide/src/controller/project.rs
+++ b/src/rust/ide/src/controller/project.rs
@@ -26,19 +26,18 @@ lazy_static! {
         let engine_version = &json["engineVersion"];
         engine_version.as_str().unwrap().to_string()
     };
+
+    /// The Engine version used in projects created in IDE.
+    pub static ref ENGINE_VERSION_FOR_NEW_PROJECTS: String = ENGINE_VERSION.to_string();
+
+    /// The requirements for Engine's version, in format understandable by
+    /// [`semver::VersionReq::parse`].
+    pub static ref ENGINE_VERSION_SUPPORTED: String = format!("^{}", ENGINE_VERSION.as_str());
 }
 
 /// The label of compiling stdlib message process.
 pub const COMPILING_STDLIB_LABEL:&str = "Compiling standard library. It can take up to 1 minute.";
 
-/// The requirements for Engine's version, in format understandable by
-/// [`semver::VersionReq::parse`].
-pub const ENGINE_VERSION_SUPPORTED        : &str = "^0.2.30";
-
-/// The Engine version used in projects created in IDE.
-// Usually it is a good idea to synchronize this version with the bundled Engine version in
-// src/js/lib/project-manager/src/build.ts. See also https://github.com/enso-org/ide/issues/1359
-pub const ENGINE_VERSION_FOR_NEW_PROJECTS : &str = "0.2.30";
 /// The minimum edition that is guaranteed to work with the IDE.
 pub const MINIMUM_EDITION_SUPPORTED : &str = "2021.18";
 
@@ -235,8 +234,8 @@ impl Project {
     }
 
     fn display_warning_on_unsupported_engine_version(&self) -> FallibleResult {
-        let requirements = semver::VersionReq::parse(ENGINE_VERSION_SUPPORTED)?;
-        let version      = self.model.engine_version();
+        let requirements = semver::VersionReq::parse(&ENGINE_VERSION_SUPPORTED)?;
+        let version = self.model.engine_version();
         if !requirements.matches(&version) {
             let message = format!("Unsupported Engine version. Please update edition in {} \
                 to {}.",package_yaml_path(&self.model.name()),MINIMUM_EDITION_SUPPORTED);
@@ -260,7 +259,6 @@ mod tests {
 
     #[test]
     fn get_engine_version() {
-        println!("{}", ENGINE_VERSION.as_str());
         assert!(!ENGINE_VERSION.is_empty());
     }
 
@@ -272,8 +270,8 @@ mod tests {
 
     #[test]
     fn new_project_engine_version_fills_requirements() {
-        let requirements = semver::VersionReq::parse(ENGINE_VERSION_SUPPORTED).unwrap();
-        let version      = semver::Version::parse(ENGINE_VERSION_FOR_NEW_PROJECTS).unwrap();
+        let requirements = semver::VersionReq::parse(&ENGINE_VERSION_SUPPORTED).unwrap();
+        let version = semver::Version::parse(&ENGINE_VERSION_FOR_NEW_PROJECTS).unwrap();
         assert!(requirements.matches(&version))
     }
 

--- a/src/rust/ide/src/ide/initializer.rs
+++ b/src/rust/ide/src/ide/initializer.rs
@@ -123,7 +123,7 @@ impl Initializer {
                 let project_name    = self.config.project_name.clone();
                 // TODO[ao]: we should think how to handle engine's versions in cloud.
                 //     https://github.com/enso-org/ide/issues/1195
-                let version = CONFIG.engine_version_for_new_projects();
+                let version = CONFIG.engine_version.clone();
                 let controller = controller::ide::Plain::from_ls_endpoints(
                     namespace,
                     project_name,
@@ -196,7 +196,7 @@ impl WithProjectManager {
             self.logger,
             "Creating a new project named '{self.project_name}'."
         );
-        let version = Some(CONFIG.engine_version_for_new_projects().to_string());
+        let version = Some(CONFIG.engine_version.to_string());
         let ProjectName(name) = &self.project_name;
         let response          = self.project_manager.create_project(name,&version,&Install);
         Ok(response.await?.project_id)

--- a/src/rust/ide/src/ide/initializer.rs
+++ b/src/rust/ide/src/ide/initializer.rs
@@ -124,14 +124,8 @@ impl Initializer {
                 // TODO[ao]: we should think how to handle engine's versions in cloud.
                 //     https://github.com/enso-org/ide/issues/1195
                 let version = CONFIG.engine_version.clone();
-                let controller = controller::ide::Plain::from_ls_endpoints(
-                    namespace,
-                    project_name,
-                    version,
-                    json_endpoint,
-                    binary_endpoint,
-                )
-                .await?;
+                let controller = controller::ide::Plain::from_ls_endpoints
+                    (namespace,project_name,version,json_endpoint,binary_endpoint).await?;
                 Ok(Rc::new(controller))
             }
         }
@@ -192,11 +186,8 @@ impl WithProjectManager {
     /// Creates a new project and returns its id, so the newly connected project can be opened.
     pub async fn create_project(&self) -> FallibleResult<Uuid> {
         use project_manager::MissingComponentAction::Install;
-        info!(
-            self.logger,
-            "Creating a new project named '{self.project_name}'."
-        );
-        let version = Some(CONFIG.engine_version.to_string());
+        info!(self.logger,"Creating a new project named '{self.project_name}'.");
+        let version           = Some(CONFIG.engine_version.to_string());
         let ProjectName(name) = &self.project_name;
         let response          = self.project_manager.create_project(name,&version,&Install);
         Ok(response.await?.project_id)

--- a/src/rust/ide/src/ide/initializer.rs
+++ b/src/rust/ide/src/ide/initializer.rs
@@ -123,9 +123,15 @@ impl Initializer {
                 let project_name    = self.config.project_name.clone();
                 // TODO[ao]: we should think how to handle engine's versions in cloud.
                 //     https://github.com/enso-org/ide/issues/1195
-                let version    = semver::Version::parse(ENGINE_VERSION_FOR_NEW_PROJECTS)?;
-                let controller = controller::ide::Plain::from_ls_endpoints
-                    (namespace,project_name,version,json_endpoint,binary_endpoint).await?;
+                let version = semver::Version::parse(&ENGINE_VERSION_FOR_NEW_PROJECTS)?;
+                let controller = controller::ide::Plain::from_ls_endpoints(
+                    namespace,
+                    project_name,
+                    version,
+                    json_endpoint,
+                    binary_endpoint,
+                )
+                .await?;
                 Ok(Rc::new(controller))
             }
         }

--- a/src/rust/ide/src/ide/initializer.rs
+++ b/src/rust/ide/src/ide/initializer.rs
@@ -3,15 +3,15 @@
 use crate::prelude::*;
 
 use crate::config;
-use crate::controller::project::ENGINE_VERSION_FOR_NEW_PROJECTS;
+use crate::controller::project::CONFIG;
 use crate::ide::Ide;
 use crate::transport::web::WebSocket;
 
 use enso_protocol::project_manager;
 use enso_protocol::project_manager::ProjectName;
-use uuid::Uuid;
 use ensogl::application::Application;
 use ensogl::system::web;
+use uuid::Uuid;
 
 
 
@@ -123,7 +123,7 @@ impl Initializer {
                 let project_name    = self.config.project_name.clone();
                 // TODO[ao]: we should think how to handle engine's versions in cloud.
                 //     https://github.com/enso-org/ide/issues/1195
-                let version = semver::Version::parse(&ENGINE_VERSION_FOR_NEW_PROJECTS)?;
+                let version = CONFIG.engine_version_for_new_projects();
                 let controller = controller::ide::Plain::from_ls_endpoints(
                     namespace,
                     project_name,
@@ -192,8 +192,11 @@ impl WithProjectManager {
     /// Creates a new project and returns its id, so the newly connected project can be opened.
     pub async fn create_project(&self) -> FallibleResult<Uuid> {
         use project_manager::MissingComponentAction::Install;
-        info!(self.logger,"Creating a new project named '{self.project_name}'.");
-        let version           = Some(ENGINE_VERSION_FOR_NEW_PROJECTS.to_owned());
+        info!(
+            self.logger,
+            "Creating a new project named '{self.project_name}'."
+        );
+        let version = Some(CONFIG.engine_version_for_new_projects().to_string());
         let ProjectName(name) = &self.project_name;
         let response          = self.project_manager.create_project(name,&version,&Install);
         Ok(response.await?.project_id)

--- a/src/rust/ide/src/ide/initializer.rs
+++ b/src/rust/ide/src/ide/initializer.rs
@@ -123,7 +123,7 @@ impl Initializer {
                 let project_name    = self.config.project_name.clone();
                 // TODO[ao]: we should think how to handle engine's versions in cloud.
                 //     https://github.com/enso-org/ide/issues/1195
-                let version = CONFIG.engine_version.clone();
+                let version    = CONFIG.engine_version.clone();
                 let controller = controller::ide::Plain::from_ls_endpoints
                     (namespace,project_name,version,json_endpoint,binary_endpoint).await?;
                 Ok(Rc::new(controller))

--- a/src/rust/ide/src/model/project/synchronized.rs
+++ b/src/rust/ide/src/model/project/synchronized.rs
@@ -174,7 +174,8 @@ impl UnsupportedEngineVersion {
         let engine_version = properties.engine_version.clone();
         let project_name   = properties.name.project.as_str().to_owned();
         move |root_cause| {
-            let requirements = semver::VersionReq::parse(controller::project::ENGINE_VERSION_SUPPORTED);
+            let requirements =
+                semver::VersionReq::parse(&controller::project::ENGINE_VERSION_SUPPORTED);
             match requirements {
                 Ok(requirements) if !requirements.matches(&engine_version) => {
                     let project_name = project_name.clone();
@@ -189,9 +190,14 @@ impl UnsupportedEngineVersion {
 impl Display for UnsupportedEngineVersion {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let package_yaml_path = controller::project::package_yaml_path(&self.project_name);
-        let version_supported = controller::project::ENGINE_VERSION_FOR_NEW_PROJECTS;
-        write!(f, "Failed to open project: unsupported engine version. Please update \
-            engine_version in {} to {}.",package_yaml_path,version_supported)
+        let version_supported = &controller::project::ENGINE_VERSION_FOR_NEW_PROJECTS;
+        write!(
+            f,
+            "Failed to open project: unsupported engine version. Please update \
+            engine_version in {} to {}.",
+            package_yaml_path,
+            version_supported.as_str()
+        )
     }
 }
 

--- a/src/rust/ide/src/model/project/synchronized.rs
+++ b/src/rust/ide/src/model/project/synchronized.rs
@@ -170,9 +170,9 @@ pub struct UnsupportedEngineVersion {
 }
 
 impl UnsupportedEngineVersion {
-    fn error_wrapper(properties: &Properties) -> impl Fn(failure::Error) -> failure::Error {
+    fn error_wrapper(properties:&Properties) -> impl Fn(failure::Error) -> failure::Error {
         let engine_version = properties.engine_version.clone();
-        let project_name = properties.name.project.as_str().to_owned();
+        let project_name   = properties.name.project.as_str().to_owned();
         move |root_cause| {
             let requirements = controller::project::CONFIG.engine_version_supported();
             match requirements {
@@ -190,12 +190,8 @@ impl Display for UnsupportedEngineVersion {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let package_yaml_path = controller::project::package_yaml_path(&self.project_name);
         let version_supported = &controller::project::CONFIG.engine_version;
-        write!(
-            f,
-            "Failed to open project: unsupported engine version. Please update \
-            engine_version in {} to {}.",
-            package_yaml_path, version_supported,
-        )
+        write!(f, "Failed to open project: unsupported engine version. Please update \
+            engine_version in {} to {}.",package_yaml_path,version_supported)
     }
 }
 

--- a/src/rust/ide/src/model/project/synchronized.rs
+++ b/src/rust/ide/src/model/project/synchronized.rs
@@ -189,7 +189,7 @@ impl UnsupportedEngineVersion {
 impl Display for UnsupportedEngineVersion {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let package_yaml_path = controller::project::package_yaml_path(&self.project_name);
-        let version_supported = controller::project::CONFIG.engine_version_for_new_projects();
+        let version_supported = &controller::project::CONFIG.engine_version;
         write!(
             f,
             "Failed to open project: unsupported engine version. Please update \

--- a/src/rust/ide/src/model/project/synchronized.rs
+++ b/src/rust/ide/src/model/project/synchronized.rs
@@ -4,12 +4,12 @@ use crate::prelude::*;
 
 use crate::double_representation::identifier::ReferentName;
 use crate::double_representation::project::QualifiedName;
-use crate::model::execution_context::VisualizationUpdateData;
-use crate::model::execution_context::synchronized::Notification as ExecutionUpdate;
 use crate::model::execution_context;
+use crate::model::execution_context::synchronized::Notification as ExecutionUpdate;
+use crate::model::execution_context::VisualizationUpdateData;
 use crate::model::module;
-use crate::model::SuggestionDatabase;
 use crate::model::traits::*;
+use crate::model::SuggestionDatabase;
 use crate::notification;
 use crate::transport::web::WebSocket;
 
@@ -170,14 +170,13 @@ pub struct UnsupportedEngineVersion {
 }
 
 impl UnsupportedEngineVersion {
-    fn error_wrapper(properties:&Properties) -> impl Fn(failure::Error) -> failure::Error {
+    fn error_wrapper(properties: &Properties) -> impl Fn(failure::Error) -> failure::Error {
         let engine_version = properties.engine_version.clone();
-        let project_name   = properties.name.project.as_str().to_owned();
+        let project_name = properties.name.project.as_str().to_owned();
         move |root_cause| {
-            let requirements =
-                semver::VersionReq::parse(&controller::project::ENGINE_VERSION_SUPPORTED);
+            let requirements = controller::project::CONFIG.engine_version_supported();
             match requirements {
-                Ok(requirements) if !requirements.matches(&engine_version) => {
+                requirements if !requirements.matches(&engine_version) => {
                     let project_name = project_name.clone();
                     UnsupportedEngineVersion {project_name,root_cause}.into()
                 }
@@ -190,13 +189,12 @@ impl UnsupportedEngineVersion {
 impl Display for UnsupportedEngineVersion {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let package_yaml_path = controller::project::package_yaml_path(&self.project_name);
-        let version_supported = &controller::project::ENGINE_VERSION_FOR_NEW_PROJECTS;
+        let version_supported = controller::project::CONFIG.engine_version_for_new_projects();
         write!(
             f,
             "Failed to open project: unsupported engine version. Please update \
             engine_version in {} to {}.",
-            package_yaml_path,
-            version_supported.as_str()
+            package_yaml_path, version_supported,
         )
     }
 }


### PR DESCRIPTION
### Pull Request Description
<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

close: #1359 

[ci no changelog needed]

Repace engine version constants in Rust and JS code with values from config in the repository root.

### Important Notes
<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist
Please include the following checklist in your PR:

- [ ] The `CHANGELOG.md` was updated with the changes introduced in this PR.
- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guide.
- [x] All code has automatic tests where possible.
- [ ] All code has been profiled where possible.
- [ ] All code has been manually tested in the IDE.
- [ ] All code has been manually tested in the "debug/interface" scene.
- [ ] All code has been manually tested by the PR owner against our [test scenarios](https://airtable.com/shr7KPRypRpanF7TO).
- [ ] All code has been manually tested by at least one reviewer against our [test scenarios](https://airtable.com/shr7KPRypRpanF7TO).
