### PR TITLE
Fix missing export of default port

### DIFF
--- a/src/js/lib/common/src/server.js
+++ b/src/js/lib/common/src/server.js
@@ -10,7 +10,7 @@ import * as portfinder    from 'portfinder'
 // === Port ===
 // ============
 
-const DEFAULT_PORT = 8080
+export const DEFAULT_PORT = 8080
 
 async function findPort(cfg) {
     if (!cfg.port) {


### PR DESCRIPTION
### Pull Request Description
Make the `DEFAULT_PORT` variable usable outside the `src/js/lib/common/src/server.js ` module. It is currently used in `src/js/lib/client/src/index.js`, which produced a warning/error as the variable was not declared with the `export` keyword. 

[ci no changelog needed]

### Checklist
Please include the following checklist in your PR:

- [ ] ~The `CHANGELOG.md` was updated with the changes introduced in this PR.~
- [ ] ~The documentation has been updated if necessary.~
- [ ] ~All code conforms to the [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guide.~
- [ ] ~All code has automatic tests where possible.~
- [ ] ~All code has been profiled where possible.~
- [ ] ~All code has been manually tested in the IDE.~
- [ ] ~All code has been manually tested in the "debug/interface" scene.~
- [ ] ~All code has been manually tested by the PR owner against our [test scenarios](https://airtable.com/shr7KPRypRpanF7TO).~
- [ ] ~All code has been manually tested by at least one reviewer against our [test scenarios](https://airtable.com/shr7KPRypRpanF7TO).~
