### PR TITLE
Fix macOS signing

### DIFF
--- a/src/js/lib/client/package.js
+++ b/src/js/lib/client/package.js
@@ -120,6 +120,7 @@ config.build = {
     },
     publish: [],
     afterAllArtifactBuild: 'tasks/computeHashes.js',
+    afterPack: 'tasks/prepareToSign.js',
     // Notarizing has been disabled due to reasons described in the relevant issue:
     // https://github.com/enso-org/ide/issues/1839
     // afterSign: "tasks/notarize.js",

--- a/src/js/lib/client/tasks/prepareToSign.js
+++ b/src/js/lib/client/tasks/prepareToSign.js
@@ -1,0 +1,13 @@
+const { beforeSign } = require('./signArchives')
+
+
+
+// ================
+// === Callback ===
+// ================
+
+exports.default = async function (context) {
+    if (context.electronPlatformName === 'darwin') {
+        beforeSign()
+    }
+}

--- a/src/js/lib/client/tasks/signArchives.js
+++ b/src/js/lib/client/tasks/signArchives.js
@@ -13,6 +13,7 @@
  dependency.
  This script should be removed once the engine is signed.
 **/
+const fs = require('fs')
 const path = require('path')
 const child_process = require('child_process')
 const { dist } = require('../../../../../build/paths')
@@ -258,6 +259,18 @@ const extra = [
     `enso/runtime/${GRAALVM}/Contents/Home/languages/R/library/survival/libs/survival.so`,
 ]
 
+// The list of readonly files in the GraalVM distribution.
+const readonly = [
+    `enso/runtime/${GRAALVM}/Contents/Home/lib/server/classes.jsa`,
+]
+
+function beforeSign() {
+    for (let file of readonly) {
+        const target = path.join(resRoot, file)
+        fs.chmodSync(target, 0o644)
+    }
+}
+
 exports.default = async function () {
     // Sign archives.
     for (let toSignData of toSign) {
@@ -275,3 +288,5 @@ exports.default = async function () {
     // Finally re-sign the top-level enso.
     sign(path.join(contentRoot, 'MacOs/Enso'))
 }
+
+module.exports = { beforeSign }


### PR DESCRIPTION
### Pull Request Description
<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

[ci no changelog needed]

GraalVM distribution contains a read-only file, that electron builder is unable to sign.
This PR makes the problematic file writeable before signing.

### Important Notes
<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist
Please include the following checklist in your PR:

- [ ] The `CHANGELOG.md` was updated with the changes introduced in this PR.
- [ ] The documentation has been updated if necessary.
- [ ] All code conforms to the [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guide.
- [ ] All code has automatic tests where possible.
- [ ] All code has been profiled where possible.
- [ ] All code has been manually tested in the IDE.
- [ ] All code has been manually tested in the "debug/interface" scene.
- [ ] All code has been manually tested by the PR owner against our [test scenarios](https://airtable.com/shr7KPRypRpanF7TO).
- [ ] All code has been manually tested by at least one reviewer against our [test scenarios](https://airtable.com/shr7KPRypRpanF7TO).
